### PR TITLE
docs: fix chezmoi docs/ bug, tighten merge rule, bilingualize docs

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -6,3 +6,4 @@ Brewfile
 .gitignore
 .pre-commit-config.yaml
 .github
+docs

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,6 +1,8 @@
 README.md
+README.zh.md
 LICENSE
 CONTRIBUTING.md
+CONTRIBUTING.zh.md
 bootstrap.sh
 Brewfile
 .gitignore

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,12 +1,12 @@
-name: Bug report
-description: Something in a config is misbehaving
+name: Bug report / Bug 报告
+description: Something in a config is misbehaving / 某份配置行为异常
 title: "fix(<scope>): <subject>"
 labels: [bug]
 body:
   - type: input
     id: affected
     attributes:
-      label: Affected package / config
+      label: Affected package / config — 受影响的包 / 配置
       description: e.g. zsh, nvim, karabiner, ghostty, bootstrap
       placeholder: zsh
     validations:
@@ -15,22 +15,22 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: What did you expect?
+      label: What did you expect? — 你期望的行为是什么？
     validations:
       required: true
 
   - type: textarea
     id: actual
     attributes:
-      label: What happened instead?
+      label: What happened instead? — 实际发生了什么？
     validations:
       required: true
 
   - type: textarea
     id: repro
     attributes:
-      label: Reproduction
-      description: Commands or steps to trigger the issue. Include `chezmoi --version`, macOS version, and any relevant `chezmoi diff` output.
+      label: Reproduction — 复现步骤
+      description: Commands or steps to trigger the issue. Include `chezmoi --version`, macOS version, and any relevant `chezmoi diff` output. / 触发问题的命令或步骤。附上 `chezmoi --version`、macOS 版本，以及相关的 `chezmoi diff` 输出。
       render: shell
     validations:
       required: true
@@ -38,4 +38,4 @@ body:
   - type: textarea
     id: workaround
     attributes:
-      label: Current workaround (if any)
+      label: Current workaround (if any) — 当前的临时绕过方案（如果有）

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,40 +1,40 @@
-name: Feature request
-description: A new tool, config, or automation to add
+name: Feature request / 功能请求
+description: A new tool, config, or automation to add / 新增工具、配置或自动化
 title: "feat(<scope>): <subject>"
 labels: [enhancement]
 body:
   - type: textarea
     id: need
     attributes:
-      label: What do you want to add, and why?
-      description: Tool name, use case, why the existing setup doesn't cover it.
+      label: What do you want to add, and why? — 想加什么？为什么？
+      description: Tool name, use case, why the existing setup doesn't cover it. / 工具名、使用场景、现有配置为何不够。
     validations:
       required: true
 
   - type: textarea
     id: approach
     attributes:
-      label: Proposed approach
+      label: Proposed approach — 建议方案
       description: |
-        - Which phase does this belong to (if part of the incremental plan)?
-        - Any chezmoi-specific design notes (new `dot_*` file? template vars? encrypted secret?)
-        - Impact on existing packages
+        - Which phase does this belong to (if part of the incremental plan)? / 归属哪个 phase（如果属于渐进计划的一部分）？
+        - Any chezmoi-specific design notes (new `dot_*` file? template vars? encrypted secret?) / chezmoi 层面的设计要点（新 `dot_*` 文件？模板变量？加密 secret？）
+        - Impact on existing packages / 对已有包的影响
 
   - type: dropdown
     id: priority
     attributes:
-      label: Priority
+      label: Priority — 优先级
       options:
-        - low — nice-to-have
-        - medium — would improve daily workflow
-        - high — blocking something
+        - low — nice-to-have / 锦上添花
+        - medium — would improve daily workflow / 改善日常流程
+        - high — blocking something / 正在卡人
     validations:
       required: true
 
   - type: checkboxes
     id: scope
     attributes:
-      label: Scope
+      label: Scope — 范围
       options:
-        - label: I plan to open a PR myself
-        - label: This is a request for someone else to implement
+        - label: I plan to open a PR myself / 我会自己开 PR
+        - label: This is a request for someone else to implement / 希望其他人来实现

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,36 +1,39 @@
 <!--
 Title should follow Conventional Commits: `<type>(<scope>?): <subject>`
 e.g. `feat(zsh): add zinit turbo plugin loader`
+
+标题遵循 Conventional Commits：`<type>(<scope>?): <subject>`
+例：`feat(zsh): add zinit turbo plugin loader`
 -->
 
-## Summary
+## Summary / 概述
 
-<!-- 1–2 sentences: what changed and why -->
+<!-- 1–2 sentences: what changed and why / 一两句：改了什么、为什么 -->
 
-## Change type
+## Change type / 变更类型
 
-<!-- Primary Conventional-Commit type -->
+<!-- Primary Conventional-Commit type / 主要的 Conventional-Commit 类型 -->
 
-- [ ] `feat` — new package / functionality
-- [ ] `fix` — bug fix
-- [ ] `chore` — infrastructure, hooks, dependency bumps
-- [ ] `docs` — documentation only
-- [ ] `refactor` — no behavior change
+- [ ] `feat` — new package / functionality · 新包或新功能
+- [ ] `fix` — bug fix · bug 修复
+- [ ] `chore` — infrastructure, hooks, dependency bumps · 基础设施 / hooks / 依赖升级
+- [ ] `docs` — documentation only · 纯文档
+- [ ] `refactor` — no behavior change · 纯重构（无行为变化）
 
-## Checklist
+## Checklist / 检查清单
 
-<!-- Tick what applies; skip what doesn't. -->
+<!-- Tick what applies; skip what doesn't. / 勾选适用项；不适用的跳过。 -->
 
-- [ ] Commit messages follow Conventional Commits
-- [ ] `pre-commit run --all-files` passes locally
-- [ ] `chezmoi diff` reviewed; no surprising deletions or permission changes
+- [ ] Commit messages follow Conventional Commits · Commit 信息符合 Conventional Commits
+- [ ] `pre-commit run --all-files` passes locally · 本地跑过 `pre-commit run --all-files` 且全绿
+- [ ] `chezmoi diff` reviewed; no surprising deletions or permission changes · 已 review `chezmoi diff`，没有意外的删除或权限变化
 
-If relevant to this PR:
+If relevant to this PR / 与本 PR 相关时：
 
-- [ ] New package → entry added to the `Layout` section of `README.md`
-- [ ] New CLI tool → added to `Brewfile`
-- [ ] Smoke-tested end-to-end on at least one Mac
+- [ ] New package → entry added to the `Layout` section of `README.md` · 新包已加入 `README.md` 的 `Layout` 小节
+- [ ] New CLI tool → added to `Brewfile` · 新 CLI 工具已加入 `Brewfile`
+- [ ] Smoke-tested end-to-end on at least one Mac · 在至少一台 Mac 上做过端到端冒烟
 
-## Notes for reviewer
+## Notes for reviewer / 给 reviewer 的说明
 
-<!-- Subtle things, tradeoffs considered, things explicitly out of scope -->
+<!-- Subtle things, tradeoffs considered, things explicitly out of scope / 微妙之处、权衡、明确不在本 PR 范围内的事项 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+> English · [中文](CONTRIBUTING.zh.md)
+
 This repo is a personal dotfiles scaffold, but it's intentionally reusable by teammates. These conventions keep the history readable and review cheap.
 
 ## Branches

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Commit messages are validated by the `commit-msg` pre-commit hook — non-confor
 ## Pull requests
 
 1. Open a PR against `main` from your `feat/<name>` branch — the [PR template](.github/pull_request_template.md) gives you the checklist
-2. Merge via the **GitHub web UI** — Squash for small PRs, Rebase for well-structured multi-commit PRs
+2. Merge via the **GitHub web UI**. **Default is Squash** — phase PRs typically ship 3–5 atomic commits whose granularity was only useful during review, and squashing keeps `main`'s log scannable. Use **Rebase** only when commits come from multiple authors, or when one PR genuinely spans multiple independent features whose history should be preserved
 
 ## Issues
 

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -1,0 +1,103 @@
+# 贡献指南
+
+> [English](CONTRIBUTING.md) · 中文
+
+本 repo 是个人 dotfiles 脚手架，但从设计上就打算让同事也能复用。下面这些约定让 git 历史保持可读、让 review 更轻。
+
+## 分支
+
+- `main` —— 永远可部署；不要直接 commit
+- `feat/<name>` —— 新包 / 新功能（如 `feat/zsh`、`feat/nvim`）
+- `fix/<name>` —— bug 修复
+- `chore/<name>` —— 杂活（CI、hooks、基础设施、README 润色）
+- `docs/<name>` —— 纯文档变更
+
+## Commits
+
+遵循 [Conventional Commits](https://www.conventionalcommits.org)：
+
+```
+<type>(<scope>?): <subject>
+```
+
+- **type**：`feat`、`fix`、`chore`、`docs`、`refactor`、`test`、`perf`、`ci`、`build`、`style`
+- **scope**（可选）：包名 —— `feat(zsh): …`、`fix(karabiner): …`
+- **subject**：祈使句、小写开头、无结尾句号
+
+body 和 footer 可选。Breaking change 写在 footer：`BREAKING CHANGE: ...`。
+
+commit 信息由 `commit-msg` pre-commit hook 校验 —— 不符合规范的消息会在本地被拒绝。
+
+## Pull Request
+
+1. 从 `feat/<name>` 分支对 `main` 开 PR —— [PR 模板](.github/pull_request_template.md) 提供了 checklist
+2. 通过 **GitHub Web UI** 合并。**默认用 Squash** —— phase PR 通常带 3–5 个 atomic commits，它们的细颗粒度只在 review 阶段有用，合并后 squash 能让 `main` 的 log 保持可扫读。仅当 commits 来自多个作者、或单个 PR 确实跨越了多个独立 feature 且需要保留历史时，才使用 **Rebase**
+
+## Issues
+
+使用提供的模板：
+
+- **Bug**：某份配置（zsh / nvim / karabiner / ...）行为异常
+- **Feature request**：新工具、新配置、新自动化
+
+空白 issue 已被禁用 —— 模板让 triage 更快。
+
+## Pre-commit hooks
+
+### 安装 pre-commit（一次性、全局）
+
+推荐路径 —— 通过 [uv](https://github.com/astral-sh/uv)（与其他 Python 工具链一致）：
+
+```bash
+# 如果还没装 uv
+brew install uv
+# …或用官方安装脚本（不依赖 Homebrew）
+# curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# 把 pre-commit 作为隔离的全局工具安装
+uv tool install pre-commit
+```
+
+不想用 uv 的备选：
+
+```bash
+brew install pre-commit     # Homebrew 管理
+# …或
+pipx install pre-commit     # 经典 pipx
+```
+
+### 为本 repo 注册 hooks（每次 clone 一次）
+
+```bash
+cd ~/.dotfiles
+pre-commit install
+```
+
+这一条命令会同时注册 `pre-commit` 和 `commit-msg` 两个 hook（配置里有 `default_install_hook_types: [pre-commit, commit-msg]`）。
+
+### 手动跑一遍
+
+```bash
+pre-commit run --all-files
+```
+
+### 升级 hook 版本
+
+```bash
+pre-commit autoupdate
+```
+
+### 当前启用的 hooks
+
+| Hook | 作用 |
+|---|---|
+| `trailing-whitespace`、`end-of-file-fixer`、`mixed-line-ending` | 空白符卫生 |
+| `check-added-large-files` | 拦截意外的大二进制 |
+| `check-json` / `check-toml` / `check-yaml` | 语法检查 |
+| `check-merge-conflict` | 捕捉残留的 conflict 标记 |
+| [`gitleaks`](https://github.com/gitleaks/gitleaks) | 扫描已提交的密钥（age key、token） |
+| [`conventional-pre-commit`](https://github.com/compilerla/conventional-pre-commit) | 在 commit-msg 阶段强制 Conventional Commits |
+
+## Secrets
+
+永远不要提交明文 secret —— `.gitignore` + `gitleaks` 双重强制。新增 / 编辑 / 轮换流程与常见陷阱见 [docs/secrets.zh.md](docs/secrets.zh.md)。

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 </p>
 
 <p align="center">
+  English · <a href="README.zh.md">中文</a>
+</p>
+
+<p align="center">
   <a href="LICENSE"><img alt="license" src="https://img.shields.io/github/license/kyriekevin/dotfiles?style=flat-square"></a>
   <a href="https://www.chezmoi.io"><img alt="managed by chezmoi" src="https://img.shields.io/badge/managed%20by-chezmoi-5fafd7?style=flat-square&logo=homeassistantcommunitystore&logoColor=white"></a>
   <a href="https://www.conventionalcommits.org"><img alt="conventional commits" src="https://img.shields.io/badge/commits-conventional-fe5196?style=flat-square&logo=conventionalcommits&logoColor=white"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -72,8 +72,8 @@ sh -c "$(curl -fsSL https://raw.githubusercontent.com/kyriekevin/dotfiles/main/b
 ├── .chezmoi.toml.tmpl            → init 交互提示 + age recipient
 ├── .chezmoiignore                → chezmoi 不管理的路径
 ├── .pre-commit-config.yaml       → 空白符 / gitleaks / conv-commits
-├── CONTRIBUTING.md               → 分支 / commit 规范
-└── README.md                     → 就是你正在看的
+├── CONTRIBUTING.zh.md            → 分支 / commit 规范
+└── README.zh.md                  → 就是你正在看的
 ```
 
 > [!NOTE]

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,105 @@
+<h1 align="center">dotfiles</h1>
+
+<p align="center">
+  <em>个人 macOS 配置，使用 <a href="https://www.chezmoi.io">chezmoi</a> + <a href="https://github.com/FiloSottile/age">age</a> 管理。</em>
+</p>
+
+<p align="center">
+  <a href="README.md">English</a> · 中文
+</p>
+
+<p align="center">
+  <a href="LICENSE"><img alt="license" src="https://img.shields.io/github/license/kyriekevin/dotfiles?style=flat-square"></a>
+  <a href="https://www.chezmoi.io"><img alt="managed by chezmoi" src="https://img.shields.io/badge/managed%20by-chezmoi-5fafd7?style=flat-square&logo=homeassistantcommunitystore&logoColor=white"></a>
+  <a href="https://www.conventionalcommits.org"><img alt="conventional commits" src="https://img.shields.io/badge/commits-conventional-fe5196?style=flat-square&logo=conventionalcommits&logoColor=white"></a>
+  <a href="https://github.com/pre-commit/pre-commit"><img alt="pre-commit" src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?style=flat-square&logo=pre-commit&logoColor=white"></a>
+</p>
+
+---
+
+## ✨ 快速开始
+
+全新 Mac 上：
+
+```bash
+# 1. 安装 Homebrew                   https://brew.sh
+
+# 2. 放入 age 私钥                   （从已有 Mac 拷出）
+mkdir -p ~/.config/chezmoi && chmod 700 ~/.config/chezmoi
+cp /path/to/key.txt ~/.config/chezmoi/key.txt && chmod 600 ~/.config/chezmoi/key.txt
+
+# 3. Bootstrap
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/kyriekevin/dotfiles/main/bootstrap.sh)"
+```
+
+首次运行时，`chezmoi init` 会询问：
+
+| 变量        | 用途                                             |
+| ----------- | ------------------------------------------------ |
+| `git_email` | 本机 `~/.gitconfig` 的主邮箱                     |
+| `is_work`   | 工作机为 `true`，个人机为 `false`                |
+
+## 🧰 工具栈
+
+`bootstrap.sh` 负责最外层的用户态栈——列在这里是为了透明：
+
+| 工具 | 作用 | 如何安装 |
+| --- | --- | --- |
+| [Homebrew](https://brew.sh) | macOS 包管理器 | `bootstrap.sh` 在缺失时非交互式安装 |
+| [chezmoi](https://www.chezmoi.io) | dotfiles 管理工具 | `brew install chezmoi`（在 bootstrap 内） |
+| [age](https://github.com/FiloSottile/age) | 密文加密 | `brew install age`（在 bootstrap 内） |
+
+贡献者专属工具（改 repo 才需要，日常使用不需要）：
+
+| 工具 | 作用 | 安装 |
+| --- | --- | --- |
+| [uv](https://github.com/astral-sh/uv) | Python 工具运行器 | `brew install uv` · 或 `curl -LsSf https://astral.sh/uv/install.sh \| sh` |
+| [pre-commit](https://pre-commit.com) | Git hooks（空白符/密钥/conventional-commits） | `uv tool install pre-commit` —— 完整流程见 [CONTRIBUTING.zh.md](CONTRIBUTING.zh.md) |
+
+## 🗂 目录结构
+
+```text
+~/.dotfiles/
+├── dot_*                         → ~/.*            （真正的 dotfiles）
+├── encrypted_private_*.age       → chmod 0600，apply 时 age 解密
+├── *.tmpl                        → 用 chezmoi data 做 Go 模板渲染
+├── run_once_before_* /           → apply 时触发的 hook
+│   run_onchange_after_*
+├── Brewfile                      → brew bundle（由 hook 触发）
+├── bootstrap.sh                  → 新 Mac 的入口脚本
+├── docs/                         → 运维手册（secrets 等）
+├── .github/                      → issue + PR 模板
+├── .chezmoi.toml.tmpl            → init 交互提示 + age recipient
+├── .chezmoiignore                → chezmoi 不管理的路径
+├── .pre-commit-config.yaml       → 空白符 / gitleaks / conv-commits
+├── CONTRIBUTING.md               → 分支 / commit 规范
+└── README.md                     → 就是你正在看的
+```
+
+> [!NOTE]
+> 本 repo 位于 `~/.dotfiles`（不是 chezmoi 默认的 `~/.local/share/chezmoi`）。每个 `chezmoi` 命令都需要带 `--source=$HOME/.dotfiles`，或者在 `~/.config/chezmoi/chezmoi.toml` 设置 `sourceDir = "~/.dotfiles"`。
+
+## 🔐 Secrets
+
+敏感信息以 [age](https://github.com/FiloSottile/age) **加密后**提交到 repo。带 `encrypted_` 前缀的文件在 `chezmoi apply` 时透明解密，使用 `~/.config/chezmoi/key.txt` 作为 age 身份（chmod 600，永不入库——由 `.gitignore` + `gitleaks` 双重强制）。
+
+无需手工步骤即可编辑加密密钥：
+
+```bash
+chezmoi edit ~/.config/zsh/secrets.zsh
+```
+
+完整手册——新机 bootstrap、新增、轮换、陷阱——见 [docs/secrets.zh.md](docs/secrets.zh.md)。
+
+## 🧪 贡献
+
+commit / 分支规范与 pre-commit 安装见 [CONTRIBUTING.zh.md](CONTRIBUTING.zh.md)。
+
+## 🔗 相关
+
+- [nousresearch/hermes-agent](https://github.com/nousresearch/hermes-agent) —— 开源 agent 框架
+- _（未来）_ 自研的 Claude Code agents / skills —— 拆出到独立 repo
+
+## 📄 License
+
+MIT —— 见 [LICENSE](LICENSE)。

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,5 +1,7 @@
 # Secrets runbook
 
+> English · [中文](secrets.zh.md)
+
 Secrets are age-encrypted at rest in this repo and decrypted transparently on `chezmoi apply`. This doc is the operator's manual — bootstrap a new Mac, add a secret, edit an existing one, rotate the key.
 
 ## How it works

--- a/docs/secrets.zh.md
+++ b/docs/secrets.zh.md
@@ -1,0 +1,88 @@
+# Secrets 运维手册
+
+> [English](secrets.md) · 中文
+
+本 repo 中的敏感信息都用 age 加密后静态存放，`chezmoi apply` 时透明解密。这份文档是操作员手册 —— 新 Mac bootstrap、新增一条 secret、编辑已有 secret、轮换密钥。
+
+## 原理
+
+| 组件 | 位置 | 是否入库？ |
+|---|---|---|
+| age **私钥**（identity） | `~/.config/chezmoi/key.txt`，chmod `600` | **不入库** —— 被 `.gitignore` + `gitleaks` 拦截 |
+| age **公钥**（recipient） | `.chezmoi.toml.tmpl` → `[age].recipient` | 入库 —— 公钥本来就可以公开 |
+| 加密后的 secret 文件 | `<source>/encrypted_private_<name>.age` | 入库 —— 只有密文 |
+| 解密后的目标文件 | `~/.config/.../<name>`（如 `~/.config/zsh/secrets.zsh`） | 被 `.gitignore` 拦截（`**/secrets.zsh`） |
+
+## 新 Mac bootstrap（在 `chezmoi init --apply` 之前）
+
+加密文件只能在拥有私钥的机器上解密。通过带外渠道拷贝：
+
+```bash
+mkdir -p ~/.config/chezmoi && chmod 700 ~/.config/chezmoi
+cp /path/to/key.txt ~/.config/chezmoi/key.txt && chmod 600 ~/.config/chezmoi/key.txt
+```
+
+可用渠道：iCloud Drive、AirDrop、U 盘。**永远不要**走邮件、Slack 或任何会被索引的通道。
+
+## 新增一条加密 secret
+
+简易路径 —— 明文已经在目标位置的情况：
+
+```bash
+chezmoi add --encrypt ~/.config/zsh/secrets.zsh
+```
+
+从零创作的路径 —— 想从头写内容、又不想让明文在硬盘上停留：
+
+```bash
+# 1. 在临时文件里写明文
+vim /tmp/secrets_plain.zsh
+
+# 2. 直接加密到 source 树（注意文件名前缀 —— 见 Gotchas）
+#    `age-keygen -y <identity>` 会从私钥文件反推公钥字符串，
+#    这是获取 recipient 的最可移植方式。
+age -r "$(age-keygen -y ~/.config/chezmoi/key.txt)" \
+    -o ~/.dotfiles/dot_config/zsh/encrypted_private_secrets.zsh.age \
+    /tmp/secrets_plain.zsh
+
+# 3. 擦明文。`rm -P` 是 BSD 版的 `shred -u`；在 APFS 上多遍覆写
+#    其实是空操作（写时复制），但 macOS 的 /tmp 本就是 volatile，
+#    所以这是"多一道防线"而不是严格保证。
+rm -P /tmp/secrets_plain.zsh 2>/dev/null || rm -f /tmp/secrets_plain.zsh
+
+# 4. 验证 chezmoi 能正确解析
+chezmoi --source=$HOME/.dotfiles managed | grep secrets.zsh
+chezmoi --source=$HOME/.dotfiles cat ~/.config/zsh/secrets.zsh
+```
+
+## 编辑已有 secret
+
+在解密后的内容上打开 `$EDITOR`，保存时重新加密：
+
+```bash
+chezmoi edit ~/.config/zsh/secrets.zsh
+chezmoi apply                 # 或：chezmoi apply ~/.config/zsh/secrets.zsh
+```
+
+## 轮换 age 密钥
+
+1. `age-keygen -o ~/.config/chezmoi/key-new.txt && chmod 600 ~/.config/chezmoi/key-new.txt` —— 生成新密钥对
+2. 对 source 里每个 `encrypted_*.age` 文件：用旧私钥解密、再用新公钥加密。**永远不要在管道里写回同一个文件** —— shell 重定向会在 `age -d` 读取之前截断 `<file>`，密文会被永久丢失。走一个临时文件：
+   ```bash
+   age -d -i ~/.config/chezmoi/key.txt <file> \
+     | age -r <new-pub> -o <file>.tmp \
+     && mv <file>.tmp <file>
+   ```
+3. 更新 `.chezmoi.toml.tmpl` 里的 `[age].recipient`，然后重新执行 `chezmoi --source=$HOME/.dotfiles init` 让模板重新渲染出 `~/.config/chezmoi/chezmoi.toml`。**不要手改渲染后的 config** —— `promptStringOnce` 的回答（`git_email`、`is_work`）已经存在它的 `[data]` 段里，init 不会再次追问
+4. 切换：`mv key-new.txt key.txt` —— **把新私钥分发到每一台需要用的 Mac**
+5. 把重新加密的文件 + recipient 变更作为一个 atomic PR 提交
+
+## Gotchas（踩过的坑）
+
+**文件名前缀的顺序有讲究。** chezmoi 从左往右解析 source attribute，但某些组合会短路。确认可用的顺序是 `encrypted_private_<name>.age`。反过来（`private_encrypted_<name>.age`）会让 `encrypted_` 留在目标文件名里，`chezmoi cat` 会把路径报成 "not managed"。
+
+**`encryption = "age"` 必须是 `chezmoi.toml` 的顶层 key。** 把它放在 `[data]` 之后，TOML 会把它解析成 `data.encryption`，chezmoi 会静默 fallback 并发出警告（`'encryption' not set, using age configuration. Check if 'encryption' is correctly set as the top-level key.`）。要放在所有 `[section]` 标题之前。
+
+**`chezmoi init --promptString key=value` 不会为 `promptStringOnce` 预填值。** "once" 变体在首次运行时总会尝试从 TTY 读。实际用起来，这只会咬非交互式 init（CI、脚本）—— 真实 Mac bootstrap 会正常交互，没问题。非交互场景下，手写 `~/.config/chezmoi/chezmoi.toml`（模板渲染出来的本来就是这个文件）。
+
+**`.gitignore` 保险绳。** `**/secrets.zsh` 拦截任何误入 source 树的明文。如果重命名目标文件或新增不同名字的 secret，要把新明文的模式也加到 `.gitignore` —— 别只靠 gitleaks。


### PR DESCRIPTION
## Summary

Three meta concerns from the post-Phase-1 bundle, shipped as one PR because they all touch documentation / scaffold hygiene and are too small to justify separate review cycles:

1. **`.chezmoiignore` bug** — `docs/` was tripping chezmoi into trying to apply the runbook to `~/docs/secrets.md` on every apply.
2. **Merge rule** — the previous wording ("Squash for small PRs, Rebase for well-structured multi-commit PRs") was subjective and would have let atomic review-time commits leak into `main`. Default is now Squash, with Rebase reserved for multi-author / multi-feature PRs.
3. **Bilingualization** — team is majority-Chinese, so an English-only scaffold carries a real onboarding tax. Main docs split into separate `.zh.md` files (cross-linked via a language switcher header); issue/PR templates use inline bilingual since GitHub's form UI doesn't support language switching.

## Test plan

- [x] `chezmoi diff` clean after the `.chezmoiignore` fix
- [x] `pre-commit run --all-files` green on every commit (whitespace / gitleaks / conventional-commits)
- [x] All 6 main doc files (3 EN + 3 ZH) cross-linked via header switcher
- [ ] Gemini review
- [ ] Spot-check the PR template rendering on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)