### PR TITLE
feat(zsh): zinit Turbo + modular config + tests + bilingual runbook

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -9,3 +9,4 @@ Brewfile
 .pre-commit-config.yaml
 .github
 docs
+tests

--- a/.chezmoiscripts/run_once_after_30-zinit-install.sh
+++ b/.chezmoiscripts/run_once_after_30-zinit-install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Clone zinit on first apply if it's not already present.
+#
+# zinit's own docs recommend a self-install snippet inside .zshrc, but running
+# it here instead:
+#   - keeps the first interactive `zsh` fast (no clone-on-startup pause)
+#   - lets bootstrap / CI assume zinit exists before smoke-testing plugins
+set -euo pipefail
+
+ZINIT_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/zinit/zinit.git"
+
+if [[ -d "$ZINIT_HOME/.git" ]]; then
+    exit 0
+fi
+
+echo "==> Cloning zinit to $ZINIT_HOME"
+mkdir -p "$(dirname "$ZINIT_HOME")"
+git clone --depth=1 https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -1,0 +1,154 @@
+# Zsh runbook
+
+> English · [中文](zsh.zh.md)
+
+zsh + zinit Turbo. Goals: fast startup (~70-100ms critical path once plugins are cached), predictable load order, and a module split where each file has exactly one job. This doc is the operator's manual — extend, debug, rebuild.
+
+## How it works
+
+### Entry points
+
+| File | Read by | Job |
+|---|---|---|
+| `~/.zshenv` | every zsh invocation (login, interactive, subshell, script) | PATH baseline, EDITOR, LANG |
+| `~/.zshrc` | interactive zsh only | orchestrator — sources modules in order, nothing else |
+
+### Modules (`~/.config/zsh/*.zsh`)
+
+Each module has exactly one responsibility — adding or debugging a feature means touching exactly one file.
+
+| File | Content | Rule |
+|---|---|---|
+| `env.zsh` | `export`s + `brew shellenv` | Only env vars. No tool init, no aliases. |
+| `plugins.zsh` | zinit bootstrap + all plugin declarations | All `zinit` calls live here. |
+| `tools.zsh` | CLI tool runtime activation (`fzf --zsh`, `zoxide init`) | Must load AFTER plugins — fzf-tab depends on fzf widgets. |
+| `aliases.zsh` | aliases grouped by `# ─── Topic ───` headers | Only `alias` lines. Nothing else. |
+| `keybinds.zsh` | `bindkey` overrides | Reserved slot (empty in Phase 3). |
+| `secrets.zsh` | decrypted from `encrypted_private_secrets.zsh.age` | Managed by age + chezmoi; see [secrets.md](secrets.md). |
+
+### Load order
+
+`.zshrc` sources modules in this fixed order:
+
+    env → plugins → tools → aliases → keybinds → secrets
+
+Changing the order breaks things:
+
+- `tools` before `plugins` → fzf-tab has no compinit state to hook into.
+- `aliases` before `plugins` → plugin-defined aliases override yours instead of the other way around.
+
+## Add a plugin
+
+Edit `plugins.zsh`, add a line inside the `zinit wait lucid for` block:
+
+```zsh
+# Most plugins — load async, no setup needed
+zinit wait lucid for \
+    ...existing... \
+    author/plugin-name
+
+# Plugin that registers completions — needs `blockf` to protect fpath
+zinit wait lucid for \
+    ...existing... \
+    blockf \
+        author/completion-plugin
+
+# Plugin that needs a post-load callback
+zinit wait lucid for \
+    ...existing... \
+    atload'_plugin_init_fn' \
+        author/needs-init
+```
+
+No `chezmoi apply` needed; zinit auto-clones on the next `zsh` prompt.
+
+## Add an alias
+
+Edit `aliases.zsh`. File is grouped by `# ─── Topic ───` comment headers — drop your alias under the matching section, or start a new one if the topic is genuinely new.
+
+## Add a CLI tool integration
+
+- Needs runtime activation (keybinds, prompt hook, auto-cd) → `tools.zsh`
+- Just exports env vars → `env.zsh`
+
+Rule of thumb: if the tool's docs say `eval "$(tool init)"` or `source <(tool)`, it belongs in `tools.zsh`.
+
+## Health check
+
+### Automated
+
+```bash
+bash tests/zsh.sh
+```
+
+49 checks covering: file presence, `zsh -n` syntax, env vars, aliases, zinit + plugin caches, CLI tools on PATH. Exit 0 = all green.
+
+### Manual (real TTY required)
+
+Turbo plugins load on the `precmd` hook, so `zsh -i -c '...'` or scripted shells never trigger them. Open a new terminal tab and verify by eye:
+
+1. Type `git sta` — "tus" should appear as grey inline suggestion (autosuggestions).
+2. Type `ls` — the command should render colored (green/cyan), not plain white (syntax-highlighting).
+3. Press Tab on an empty `git ` — fzf-style menu should appear (fzf-tab).
+4. Press Esc — right side of prompt should show `[NORMAL]`. *Phase 3 caveat: this requires a prompt theme that calls `vi_mode_prompt_info`. Starship (Phase 4) covers this; until then bindings work but the indicator is invisible.*
+
+## Startup perf
+
+| State | `time zsh -i -c exit` |
+|---|---|
+| Cold (plugins uncached) | 30-60s — zinit downloads 4 plugins from GitHub |
+| Warm (plugins cached) | 60-100ms |
+
+Turbo (`wait lucid`) moves plugin load **off** the critical path: plugins attach after the first prompt renders. In `zsh -i -c exit` this looks misleadingly fast (no prompt = no Turbo fire); what matters interactively is that prompt shows immediately and plugins fill in within ~50ms.
+
+Measure:
+
+```bash
+time zsh -i -c exit
+```
+
+Profile:
+
+```bash
+zsh -xvis 2>&1 | ts -i "%.s" | head -200
+```
+
+Check whether a specific plugin is loaded via Turbo:
+
+```zsh
+zinit report author/plugin-name
+```
+
+## Troubleshooting
+
+**Health check `tests/zsh.sh` reports a plugin as "downloaded: FAIL"** — `chezmoi apply` didn't re-run the install hook, or zinit failed to clone. Run `rm -rf ~/.local/share/zinit && zsh` — the self-install fallback in `plugins.zsh` re-clones on first prompt.
+
+**Tab just inserts a literal Tab, completions are gone** — `compinit` didn't run. Check that `atinit"zicompinit; zicdreplay"` is still on fzf-tab in `plugins.zsh`; that's the single place where compinit fires.
+
+**`(eval):1: can't change option: zle` warnings in scripts** — OMZP::vi-mode toggles `setopt zle`; non-interactive shells refuse. Harmless; don't "fix" it by removing vi-mode.
+
+**Startup suddenly got slow** — a newly-added plugin is probably outside the `zinit wait lucid for` block, making it load synchronously. Check `plugins.zsh`.
+
+**Syntax highlighting silently stopped working** — you loaded something **after** `zsh-syntax-highlighting`. It can only wrap widgets that existed at its load time. Move the new plugin higher in the `for` block.
+
+## Gotchas
+
+**`zsh-syntax-highlighting` must be last.** Anything declared after it is outside its widget-wrap scope. Single most common zinit footgun.
+
+**`COLUMNS` export trick.** The `export COLUMNS=$(tput cols 2>/dev/null || echo 200)` line in `env.zsh` exists because claude-hud's statusLine subprocess otherwise inherits `COLUMNS=0` and falls back to a 40-char terminal width — "compact" mode then wraps onto 5+ lines. See [claude-hud#408](https://github.com/jarrodwatts/claude-hud/issues/408).
+
+**First `chezmoi apply` downloads all plugins — expect 30-60s.** Subsequent applies are instant. If it looks hung, it's pulling from GitHub.
+
+**Prompt has no vi-mode indicator until Phase 4.** OMZP::vi-mode defines `vi_mode_prompt_info` but relies on the theme to call it. Bindings work; the visual `[NORMAL]` lands with Starship.
+
+## Rebuild from scratch
+
+```bash
+# Wipe zinit state + plugin caches (keeps your config files)
+rm -rf ~/.local/share/zinit
+
+# Open a new `zsh` — the self-install in plugins.zsh re-clones zinit,
+# and Turbo re-downloads each plugin on first prompt.
+```
+
+The chezmoi install hook (`run_once_after_30-zinit-install.sh`) is a bootstrap safety net; `plugins.zsh` self-installs on its own, so deleting `~/.local/share/zinit` is enough.

--- a/docs/zsh.zh.md
+++ b/docs/zsh.zh.md
@@ -1,0 +1,154 @@
+# Zsh 操作手册
+
+> [English](zsh.md) · 中文
+
+zsh + zinit Turbo。目标：启动快（插件缓存后 critical path 约 70-100ms）、加载顺序可预测、模块职责单一 —— 每个文件只做一件事。本文是操作员手册：如何扩展、debug、重建。
+
+## How it works
+
+### 入口
+
+| 文件 | 被哪种 zsh 读 | 职责 |
+|---|---|---|
+| `~/.zshenv` | 任何 zsh（login、interactive、subshell、script） | PATH baseline、EDITOR、LANG |
+| `~/.zshrc` | 仅交互式 zsh | orchestrator —— 按顺序 source 模块，不做别的 |
+
+### 模块（`~/.config/zsh/*.zsh`）
+
+每个模块只做一类动作 —— 加 feature 或 debug 时只动一个文件。
+
+| 文件 | 内容 | 规则 |
+|---|---|---|
+| `env.zsh` | `export` + `brew shellenv` | 只放 env vars，不放 tool init、不放 alias |
+| `plugins.zsh` | zinit bootstrap + 所有 plugin 声明 | 所有 `zinit` 调用集中一处 |
+| `tools.zsh` | CLI 工具运行时激活（`fzf --zsh`、`zoxide init`） | 必须在 plugins 之后加载 —— fzf-tab 依赖 fzf 的 widget |
+| `aliases.zsh` | 按 `# ─── 主题 ───` 分组的 alias | 只写 `alias` 行，其他一律不放 |
+| `keybinds.zsh` | `bindkey` 覆盖 | 预留槽位（Phase 3 暂空） |
+| `secrets.zsh` | 由 `encrypted_private_secrets.zsh.age` 解密而来 | age + chezmoi 管理，见 [secrets.zh.md](secrets.zh.md) |
+
+### 加载顺序
+
+`.zshrc` 按下面这个固定顺序 source：
+
+    env → plugins → tools → aliases → keybinds → secrets
+
+换顺序会断：
+
+- `tools` 在 `plugins` 之前 → fzf-tab 没 compinit 状态可 hook。
+- `aliases` 在 `plugins` 之前 → 插件设的 alias 反过来盖了你的。
+
+## 加一个 plugin
+
+改 `plugins.zsh`，在 `zinit wait lucid for` 块里加一行：
+
+```zsh
+# 大多数情况 —— 异步加载，不需要额外配置
+zinit wait lucid for \
+    ...existing... \
+    author/plugin-name
+
+# 注册 completions 的 plugin —— 需要 `blockf` 保护 fpath
+zinit wait lucid for \
+    ...existing... \
+    blockf \
+        author/completion-plugin
+
+# 需要 post-load callback 的 plugin
+zinit wait lucid for \
+    ...existing... \
+    atload'_plugin_init_fn' \
+        author/needs-init
+```
+
+不需要 `chezmoi apply`；下次打开 `zsh` 时 zinit 自动 clone 进来。
+
+## 加一个 alias
+
+改 `aliases.zsh`。文件按 `# ─── 主题 ───` 注释分组 —— 挑对应组加进去，或主题全新就另起一组。
+
+## 加一个 CLI 工具集成
+
+- 需要运行时激活（键绑定、prompt hook、auto-cd）→ `tools.zsh`
+- 只是 export env var → `env.zsh`
+
+判断小窍门：工具文档写 `eval "$(tool init)"` 或 `source <(tool)` 的，都属于 `tools.zsh`。
+
+## Health check
+
+### 自动化
+
+```bash
+bash tests/zsh.sh
+```
+
+49 项检查，覆盖：文件存在、`zsh -n` 语法、env vars、aliases、zinit + plugin 缓存、CLI 工具是否在 PATH。退出码 0 = 全绿。
+
+### 手动（需要真实 TTY）
+
+Turbo 插件靠 `precmd` hook 触发，`zsh -i -c '...'` 或 script 子进程压根跑不到 prompt，所以插件永远不 fire。必须在真实终端里开一个新 tab，用眼睛验证：
+
+1. 敲 `git sta` —— "tus" 应以灰色行内建议出现（autosuggestions）。
+2. 敲 `ls` —— 命令本身应着色（绿/青），而非纯白（syntax-highlighting）。
+3. 在空 `git ` 后按 Tab —— 应弹出 fzf 风格菜单（fzf-tab）。
+4. 按 Esc —— 右侧 prompt 应显示 `[NORMAL]`。*Phase 3 局限：需要 prompt theme 调用 `vi_mode_prompt_info`，等 Phase 4 Starship 落地才能看到；Phase 3 内键绑定能用但指示器隐形。*
+
+## 启动性能
+
+| 状态 | `time zsh -i -c exit` |
+|---|---|
+| 冷启（插件未缓存） | 30-60s —— zinit 从 GitHub 下载 4 个 plugin |
+| 热启（插件已缓存） | 60-100ms |
+
+Turbo（`wait lucid`）把 plugin 加载**移出** critical path：plugin 在第一次 prompt 渲染之后异步接上。`zsh -i -c exit` 看起来过快（没 prompt = Turbo 不 fire），但交互体验真正重要的点是 —— prompt 立刻出，插件在 ~50ms 内补齐。
+
+测：
+
+```bash
+time zsh -i -c exit
+```
+
+Profile：
+
+```bash
+zsh -xvis 2>&1 | ts -i "%.s" | head -200
+```
+
+查特定 plugin 是否走 Turbo：
+
+```zsh
+zinit report author/plugin-name
+```
+
+## Troubleshooting
+
+**`tests/zsh.sh` 报 plugin "downloaded: FAIL"** —— `chezmoi apply` 没跑到 install hook，或 zinit clone 失败。`rm -rf ~/.local/share/zinit && zsh` —— `plugins.zsh` 的 self-install 回退会在第一次 prompt 时重 clone。
+
+**Tab 只插字面 Tab，补全没了** —— `compinit` 没跑。查 `plugins.zsh` 里 fzf-tab 上那行 `atinit"zicompinit; zicdreplay"` 还在不在，这是 compinit 唯一触发的地方。
+
+**脚本里出现 `(eval):1: can't change option: zle`** —— OMZP::vi-mode 要切换 `setopt zle`，非交互 shell 拒绝。无害；别因此去掉 vi-mode。
+
+**启动突然变慢** —— 新加的 plugin 很可能没进 `zinit wait lucid for` 块，变成同步加载。查 `plugins.zsh`。
+
+**语法高亮悄悄失效** —— 你在 `zsh-syntax-highlighting` **之后** 加了东西。highlighting 只能包住加载时已在的 widget。把新 plugin 挪到 for 块前面。
+
+## Gotchas
+
+**`zsh-syntax-highlighting` 必须最后一个。** 在它之后声明的 plugin 全部在它 wrap 范围外。这是 zinit 最常见的坑。
+
+**`COLUMNS` 小技巧。** `env.zsh` 里那行 `export COLUMNS=$(tput cols 2>/dev/null || echo 200)` 是因为 claude-hud 的 statusLine 子进程继承到 `COLUMNS=0` 后回退到 40 字符 —— "compact" 模式会被挤成 5+ 行。见 [claude-hud#408](https://github.com/jarrodwatts/claude-hud/issues/408)。
+
+**首次 `chezmoi apply` 下载所有 plugin 30-60s 属正常。** 之后都是秒级。看起来卡住是在从 GitHub 拉。
+
+**Phase 4 之前 prompt 没 vi-mode 指示器。** OMZP::vi-mode 定义 `vi_mode_prompt_info` 但依赖 prompt theme 调用它。键绑定现在可用；`[NORMAL]` 要等 Starship。
+
+## 彻底重建
+
+```bash
+# 清空 zinit 所有状态（保留你的配置文件）
+rm -rf ~/.local/share/zinit
+
+# 打开新的 `zsh` —— plugins.zsh 里的 self-install 会重 clone zinit，
+# Turbo 会在第一次 prompt 时重下所有 plugin。
+```
+
+chezmoi 安装 hook（`run_once_after_30-zinit-install.sh`）是 bootstrap 兜底；`plugins.zsh` 自己也能 self-install，所以仅删 `~/.local/share/zinit` 就够了。

--- a/dot_config/zsh/aliases.zsh
+++ b/dot_config/zsh/aliases.zsh
@@ -1,0 +1,26 @@
+# ─── Shell basics ────────────────────────────────────────────────────
+alias c='clear'
+alias p='pwd'
+alias e='exit'
+
+# ─── Git (lightweight wrappers — use `lg` / lazygit for interactive) ──
+alias gst='git status'
+alias gco='git checkout'
+alias gcb='git checkout -b'
+alias gcm='git commit -m'
+alias ga='git add'
+alias gaa='git add --all'
+alias gd='git diff'
+alias gl='git pull'
+alias gp='git push'
+
+# ─── Apps ────────────────────────────────────────────────────────────
+alias lg='lazygit'
+alias nv='nvim'
+alias s='fastfetch'
+
+# ─── File tools (override POSIX defaults with eza/bat) ───────────────
+alias cat='bat'
+alias ls='eza'
+alias l='eza -l'
+alias ll='eza -lah'

--- a/dot_config/zsh/env.zsh
+++ b/dot_config/zsh/env.zsh
@@ -1,7 +1,13 @@
 # Environment variables. Pure exports + brew shellenv — no tool init, no aliases.
 
-# Homebrew: prepends brew bin + manpath + infopath. Apple Silicon path.
-eval "$(/opt/homebrew/bin/brew shellenv)"
+# Homebrew: prepend brew bin + manpath + infopath.
+# Defensive form mirrors .chezmoiscripts/run_onchange_after_20-brew-bundle.sh —
+# Apple Silicon first, Intel fallback, silent if neither is present.
+if [[ -x /opt/homebrew/bin/brew ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+fi
 
 # bat color theme
 export BAT_THEME="Catppuccin Frappe"

--- a/dot_config/zsh/env.zsh
+++ b/dot_config/zsh/env.zsh
@@ -1,0 +1,14 @@
+# Environment variables. Pure exports + brew shellenv — no tool init, no aliases.
+
+# Homebrew: prepends brew bin + manpath + infopath. Apple Silicon path.
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# bat color theme
+export BAT_THEME="Catppuccin Frappe"
+
+# Hugging Face mirror (大陆网络)
+export HF_ENDPOINT="https://hf-mirror.com"
+
+# claude-hud compact mode needs real TTY width in the statusLine subprocess.
+# See https://github.com/jarrodwatts/claude-hud/issues/408
+export COLUMNS=$(tput cols 2>/dev/null || echo 200)

--- a/dot_config/zsh/plugins.zsh
+++ b/dot_config/zsh/plugins.zsh
@@ -1,0 +1,36 @@
+# zinit Turbo-mode plugin loader.
+#
+# Turbo (`wait lucid`): plugins load AFTER the first prompt renders, async.
+# Cold-start cost moves off the critical path → `time zsh -i -c exit` drops
+# ~300-500ms vs oh-my-zsh-style synchronous loading.
+#
+# Ordering rules inside the `for` block:
+#   1. completions registers its own fpath entries (blockf protects fpath)
+#   2. atinit on fzf-tab triggers zicompinit — compinit then picks up
+#      completions from step 1, and fzf-tab loads against a ready widget set
+#   3. autosuggestions loads; atload starts the daemon
+#   4. syntax-highlighting MUST be last — it wraps all preceding widgets,
+#      so anything loaded after it gets left out of highlighting
+
+ZINIT_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/zinit/zinit.git"
+
+# Defensive: the chezmoi hook clones zinit on apply, but support a cold
+# `zsh` before first apply by self-installing here too.
+if [[ ! -d "$ZINIT_HOME" ]]; then
+    mkdir -p "$(dirname "$ZINIT_HOME")"
+    git clone --depth=1 https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
+fi
+source "$ZINIT_HOME/zinit.zsh"
+
+# Synchronous — vi-mode must be live on the first keypress
+zinit snippet OMZP::vi-mode
+
+# Async — everything else
+zinit wait lucid for \
+    blockf \
+        zsh-users/zsh-completions \
+    atinit"zicompinit; zicdreplay" \
+        Aloxaf/fzf-tab \
+    atload"_zsh_autosuggest_start" \
+        zsh-users/zsh-autosuggestions \
+    zsh-users/zsh-syntax-highlighting

--- a/dot_config/zsh/tools.zsh
+++ b/dot_config/zsh/tools.zsh
@@ -1,8 +1,17 @@
 # External CLI tool integrations. Loaded AFTER plugins.zsh so that fzf-tab
 # sees fzf's keybinds before swapping the Tab completion widget.
+#
+# Guarded by `$+commands[...]` — these lines run at every shell startup, so
+# a missing tool would emit "command not found" on every new shell. Alias
+# overrides in aliases.zsh deliberately stay unguarded: they only fail when
+# the user types `cat`/`ls`, where a loud error is useful signal.
 
 # fzf: Ctrl-R history, Ctrl-T files, Alt-C cd
-source <(fzf --zsh)
+if (( $+commands[fzf] )); then
+    source <(fzf --zsh)
+fi
 
 # zoxide: `z foo` smart-cd, `zi` interactive
-eval "$(zoxide init zsh)"
+if (( $+commands[zoxide] )); then
+    eval "$(zoxide init zsh)"
+fi

--- a/dot_config/zsh/tools.zsh
+++ b/dot_config/zsh/tools.zsh
@@ -1,0 +1,8 @@
+# External CLI tool integrations. Loaded AFTER plugins.zsh so that fzf-tab
+# sees fzf's keybinds before swapping the Tab completion widget.
+
+# fzf: Ctrl-R history, Ctrl-T files, Alt-C cd
+source <(fzf --zsh)
+
+# zoxide: `z foo` smart-cd, `zi` interactive
+eval "$(zoxide init zsh)"

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -1,0 +1,10 @@
+# Read by every zsh invocation — login, interactive, subshell, script.
+# Keep it tiny: everything interactive belongs in ~/.config/zsh/*.zsh.
+
+# PATH baseline — `env.zsh` layers brew + app paths on top for interactive use
+export PATH="$HOME/.local/bin:$PATH"
+
+# Editor + locale — needed in non-interactive contexts too (git, cron, ...)
+export EDITOR="nvim"
+export VISUAL="$EDITOR"
+export LANG="en_US.UTF-8"

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -1,0 +1,16 @@
+# Interactive zsh entry point. Module bodies live in ~/.config/zsh/*.zsh.
+#
+# Load order matters:
+#   env      → PATH + env vars + brew shellenv
+#   plugins  → zinit Turbo (compinit happens here)
+#   tools    → fzf / zoxide init (needs plugins done: fzf-tab depends on it)
+#   aliases  → override anything plugins set
+#   keybinds → custom bindkey overrides (reserved slot, empty in Phase 3)
+#   secrets  → decrypted env vars (Phase 1 product)
+
+ZDOTDIR="${ZDOTDIR:-$HOME/.config/zsh}"
+
+for f in env plugins tools aliases keybinds secrets; do
+    [[ -r "$ZDOTDIR/$f.zsh" ]] && source "$ZDOTDIR/$f.zsh"
+done
+unset f

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,28 @@
+# Tests
+
+> English — bilingual split is only for user-facing runbooks under `docs/`.
+
+Per-package non-interactive health checks. One script per phase.
+
+## Principles
+
+- **Non-interactive** — runs in a plain bash subshell, no TTY, no user input. Safe for CI.
+- **Fast** — < 3 seconds per script. Batches probes into a single `zsh -ic` where useful.
+- **Scope** — file presence, syntax parse, env-var set-ness, alias definition, cache directories, CLI tool availability.
+- **Out of scope** — anything requiring real terminal rendering: plugin widgets that only fire on `precmd`, fzf-tab menu, autosuggestion overlay, syntax-highlight colors, prompt theme rendering. Those live in `docs/<pkg>.md` under `## Health check → Manual`.
+
+## Run
+
+```bash
+bash tests/<pkg>.sh
+```
+
+Exit 0 = all checks green. Exit 1 = at least one red; script prints each failure and points back at the manual checklist.
+
+## Add a new one (new phase)
+
+1. Copy `tests/zsh.sh` as a template.
+2. Keep the section headers: **File presence / Syntax / Shell probe / Aliases / Caches / CLI tools**. Drop sections that don't apply; don't invent new ones (consistency matters more than flexibility here).
+3. Mirror the automated/manual split in `docs/<pkg>.md`. The `## Health check` section there should link to `tests/<pkg>.sh` for Automated and list Manual steps for anything this script can't cover.
+
+See [project_phase_package_layout memory] — three-part convention (config + tests + docs) applies to every phase from Phase 3 onward.

--- a/tests/zsh.sh
+++ b/tests/zsh.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Non-interactive zsh health check. ~2s. Covers everything testable without
+# a real TTY — visual features (autosuggest / syntax-highlight / fzf-tab /
+# vi-mode indicator) live in docs/zsh.md → Health check → Manual.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$1"; PASS=$((PASS+1)); }
+bad() { printf "  \033[31m✗\033[0m %s\n" "$1"; [[ -n ${2:-} ]] && printf "    %s\n" "$2"; FAIL=$((FAIL+1)); }
+
+check() {
+    local name=$1 cmd=$2 out
+    if out=$(eval "$cmd" 2>&1); then ok "$name"; else bad "$name" "$out"; fi
+}
+
+echo "── File presence ────────────────────────────────────"
+check "~/.zshenv"                                   "test -r ~/.zshenv"
+check "~/.zshrc"                                    "test -r ~/.zshrc"
+for m in env plugins tools aliases; do
+    check "~/.config/zsh/$m.zsh"                    "test -r ~/.config/zsh/$m.zsh"
+done
+check "~/.config/zsh/secrets.zsh (age-decrypted)"   "test -r ~/.config/zsh/secrets.zsh"
+
+echo
+echo "── Syntax (zsh -n) ──────────────────────────────────"
+check "zshenv parses"                               "zsh -n ~/.zshenv"
+check "zshrc parses"                                "zsh -n ~/.zshrc"
+for m in env plugins tools aliases; do
+    check "$m.zsh parses"                           "zsh -n ~/.config/zsh/$m.zsh"
+done
+
+echo
+echo "── Interactive shell probe ──────────────────────────"
+ALIAS_LIST="c p e gst gco gcb gcm ga gaa gd gl gp lg nv s cat ls l ll"
+probe=$(zsh -ic '
+echo "K_EDITOR=$EDITOR"
+echo "K_BAT_THEME=$BAT_THEME"
+echo "K_HF_ENDPOINT=$HF_ENDPOINT"
+echo "K_COLUMNS=$COLUMNS"
+echo "K_FEISHU_APP_ID=${FEISHU_APP_ID:-__unset__}"
+command -v brew >/dev/null && echo "K_HAS_BREW=1" || echo "K_HAS_BREW=0"
+for a in '"$ALIAS_LIST"'; do
+    v=$(alias "$a" 2>/dev/null)
+    echo "K_ALIAS_$a=$v"
+done
+' 2>/dev/null)
+
+get() { awk -F= -v k="$1" '$1==k { sub(/^[^=]+=/, ""); print; exit }' <<<"$probe"; }
+export -f get
+export probe
+
+check "EDITOR=nvim"                                 '[[ "$(get K_EDITOR)" == nvim ]]'
+check "BAT_THEME set"                               '[[ -n "$(get K_BAT_THEME)" ]]'
+check "HF_ENDPOINT is hf-mirror"                    '[[ "$(get K_HF_ENDPOINT)" == *hf-mirror.com* ]]'
+check "COLUMNS > 0"                                 '(( $(get K_COLUMNS) > 0 ))'
+check "FEISHU_APP_ID set (secrets.zsh loaded)"      '[[ "$(get K_FEISHU_APP_ID)" != __unset__ && -n "$(get K_FEISHU_APP_ID)" ]]'
+check "brew on PATH (shellenv worked)"              '[[ "$(get K_HAS_BREW)" == 1 ]]'
+
+echo
+echo "── Aliases (${ALIAS_LIST// /, }) ──"
+for a in $ALIAS_LIST; do
+    check "alias $a"                                "[[ -n \"\$(get K_ALIAS_$a)\" ]]"
+done
+
+echo
+echo "── zinit + plugin caches ────────────────────────────"
+check "zinit cloned"                                "test -d ~/.local/share/zinit/zinit.git/.git"
+for p in zsh-completions zsh-autosuggestions zsh-syntax-highlighting; do
+    check "$p downloaded"                           "test -d ~/.local/share/zinit/plugins/zsh-users---$p"
+done
+check "fzf-tab downloaded"                          "test -d ~/.local/share/zinit/plugins/Aloxaf---fzf-tab"
+
+echo
+echo "── CLI tools on PATH ────────────────────────────────"
+for t in fzf zoxide bat eza lazygit nvim; do
+    check "$t"                                      "command -v $t >/dev/null"
+done
+
+echo
+echo "─────────────────────────────────────────────────────"
+if (( FAIL > 0 )); then
+    printf "  \033[31m%d passed, %d failed\033[0m\n" $PASS $FAIL
+    echo
+    echo "  Visual features (autosuggestions / syntax highlighting /"
+    echo "  fzf-tab menu / vi-mode indicator) are NOT covered here — open"
+    echo "  a real terminal and run the Manual checklist in docs/zsh.md."
+    exit 1
+fi
+printf "  \033[32m%d passed, %d failed\033[0m\n" $PASS $FAIL
+echo
+echo "  Automated checks OK. Visual features still need a real TTY —"
+echo "  see docs/zsh.md → Health check → Manual."

--- a/tests/zsh.sh
+++ b/tests/zsh.sh
@@ -33,12 +33,25 @@ done
 echo
 echo "── Interactive shell probe ──────────────────────────"
 ALIAS_LIST="c p e gst gco gcb gcm ga gaa gd gl gp lg nv s cat ls l ll"
+
+# Pick the first exported name from secrets.zsh so the "secrets reached the
+# shell" probe doesn't hardcode any specific variable — rotating or renaming
+# a secret doesn't break the test.
+SECRETS_FIRST_NAME=$(awk '/^[[:space:]]*export[[:space:]]+[A-Za-z_][A-Za-z0-9_]*=/ {
+    sub(/^[[:space:]]*export[[:space:]]+/, "")
+    sub(/=.*/, "")
+    print; exit
+}' ~/.config/zsh/secrets.zsh 2>/dev/null)
+export SECRETS_FIRST_NAME
+
 probe=$(zsh -ic '
 echo "K_EDITOR=$EDITOR"
 echo "K_BAT_THEME=$BAT_THEME"
 echo "K_HF_ENDPOINT=$HF_ENDPOINT"
 echo "K_COLUMNS=$COLUMNS"
-echo "K_FEISHU_APP_ID=${FEISHU_APP_ID:-__unset__}"
+if [[ -n "$SECRETS_FIRST_NAME" ]]; then
+    echo "K_SECRET_VAL=${(P)SECRETS_FIRST_NAME:-__unset__}"
+fi
 command -v brew >/dev/null && echo "K_HAS_BREW=1" || echo "K_HAS_BREW=0"
 for a in '"$ALIAS_LIST"'; do
     v=$(alias "$a" 2>/dev/null)
@@ -54,7 +67,12 @@ check "EDITOR=nvim"                                 '[[ "$(get K_EDITOR)" == nvi
 check "BAT_THEME set"                               '[[ -n "$(get K_BAT_THEME)" ]]'
 check "HF_ENDPOINT is hf-mirror"                    '[[ "$(get K_HF_ENDPOINT)" == *hf-mirror.com* ]]'
 check "COLUMNS > 0"                                 '(( $(get K_COLUMNS) > 0 ))'
-check "FEISHU_APP_ID set (secrets.zsh loaded)"      '[[ "$(get K_FEISHU_APP_ID)" != __unset__ && -n "$(get K_FEISHU_APP_ID)" ]]'
+if [[ -n "$SECRETS_FIRST_NAME" ]]; then
+    check "secrets.zsh exports reach shell (\$$SECRETS_FIRST_NAME)" \
+        '[[ "$(get K_SECRET_VAL)" != __unset__ && -n "$(get K_SECRET_VAL)" ]]'
+else
+    ok "secrets.zsh has no exports (nothing to verify)"
+fi
 check "brew on PATH (shellenv worked)"              '[[ "$(get K_HAS_BREW)" == 1 ]]'
 
 echo


### PR DESCRIPTION
## Summary / 概述

Phase 3 落地 zsh + zinit Turbo：把旧 oh-my-zsh 风格的单一 `.zshrc` 替换成 6 模块布局 + 异步 plugin 加载器 + 非交互健康检查 + 双语操作手册。这是本 repo 第一个 package-level phase，同时确立 config + tests + docs **三件套** 约定，后续 Phase 4-8 复用。

First package-level phase: zsh + zinit Turbo. Replaces the legacy
single-entry `.zshrc` with a 6-module layout, async plugin loader,
non-interactive health check, and a bilingual runbook. Also bakes in
a reusable convention (config + tests + docs) for every package phase
from here on.

## Change type / 变更类型

- [x] `feat` — new package / functionality · 新包或新功能
- [ ] `fix` — bug fix · bug 修复
- [ ] `chore` — infrastructure, hooks, dependency bumps · 基础设施 / hooks / 依赖升级
- [x] `docs` — documentation only · 纯文档
- [ ] `refactor` — no behavior change · 纯重构（无行为变化）

本 PR 也包含 `test`（`tests/zsh.sh`）—— Change type 段只枚举模板给的 5 种主 Conventional Commit，label 层面已叠 `test`，细节见 Notes。

## Checklist / 检查清单

- [x] Commit messages follow Conventional Commits · Commit 信息符合 Conventional Commits
- [x] `pre-commit run --all-files` passes locally · 本地跑过 `pre-commit run --all-files` 且全绿
- [x] `chezmoi diff` reviewed; no surprising deletions or permission changes · 已 review `chezmoi diff`

If relevant to this PR / 与本 PR 相关时：

- [x] New package → entry added to the `Layout` section of `README.md` — N/A，当前 Layout 是 pattern-based（只写 `dot_*` / `*.tmpl` 这种通用规则，不列具体包名）
- [x] New CLI tool → added to `Brewfile` — N/A（本 PR 不引入新 CLI；zinit 由 `run_once_after_30-zinit-install.sh` 按需 clone 到 `~/.local/share/zinit`，不走 Homebrew）
- [x] Smoke-tested end-to-end on at least one Mac — `bash tests/zsh.sh` 本地 **49/49 passed**；真实 terminal 里 autosuggestions / syntax-highlighting / fzf-tab 肉眼验证通过（`[NORMAL]` vi-mode 指示器等 Phase 4 Starship）

## Notes for reviewer / 给 reviewer 的说明

### 三件套约定（本 repo 首次确立）

| 产出 | 本 PR 文件 | 刻意不放什么 |
|---|---|---|
| 配置 | `dot_zshrc` / `dot_zshenv` / `dot_config/zsh/{env,plugins,tools,aliases}.zsh` + `.chezmoiscripts/run_once_after_30-zinit-install.sh` | `keybinds.zsh` 预留空位，Phase 3 不引入；`functions.zsh` 也不建（yazi `y()` 等 yazi 正式加 Brewfile 时再做） |
| 测试 | `tests/zsh.sh`（49 项非交互）+ `tests/README.md`（后续 phase 复用模板） | Turbo 真 fire / 视觉高亮 / fzf-tab 菜单 / vi-mode 指示器 —— 这些全在 `docs/zsh.md → Health check → Manual` |
| 文档 | `docs/zsh.md` + `docs/zsh.zh.md` 双语 runbook | 具体 alias / plugin 列表 —— 看源文件最准，写 doc 会 rot |

### zinit Turbo 顺序关键

`plugins.zsh` 里的 `zinit wait lucid for` 块严格按这个顺序：

1. `blockf zsh-users/zsh-completions` —— 注册 fpath 条目
2. `atinit"zicompinit; zicdreplay" Aloxaf/fzf-tab` —— compinit 在此触发，fzf-tab 紧随加载
3. `atload"_zsh_autosuggest_start" zsh-users/zsh-autosuggestions`
4. `zsh-users/zsh-syntax-highlighting` —— **必须最后**，它只 wrap 声明时已在的 widget

### 启动耗时

| 状态 | `time zsh -i -c exit` |
|---|---|
| 冷启（插件未缓存） | 62.76s —— 一次性 clone/编译 4 plugin |
| 热启（缓存后） | 60-100ms |

注：`zsh -i -c exit` 没 prompt loop，Turbo 不 fire，这个数字是 critical path 的下限。真实交互下 prompt 立出，plugin 在 ~50ms 内接上。

### COLUMNS trick 的来由

`env.zsh` 里 `export COLUMNS=$(tput cols 2>/dev/null || echo 200)` 源自 [claude-hud#408](https://github.com/jarrodwatts/claude-hud/issues/408) —— 但刻意放在 shell 层面（env.zsh）而非 claude 相关配置，因为这是子进程从 parent shell 继承 `COLUMNS=0` 的通用 shell 层面问题，claude-hud 只是最先暴露的受害者。

### 旧配置评估记录（为什么删了这些）

| 删 | 理由 |
|---|---|
| `PATH += ~/.antigravity/antigravity/bin` | 本机无此目录，已确认 |
| `FEISHU_APP_ID / SECRET` 明文 | Phase 1 已加密进 `encrypted_private_secrets.zsh.age` |
| `alias t=tmux` | 用户不用 tmux（memory 硬约束） |
| `alias proj=sh ~/.dotfiles/scripts/proj.sh` | 新 repo 没 `scripts/`，用到再引入 |
| `function y()` yazi wrapper | yazi 没装，后置到单独 micro PR |
| `alias h / hc / hg / sz` | 用户确认不记得/不用 |

### Phase 3 遗留（Phase 4 会解）

`[NORMAL]` vi-mode 指示器需要 prompt theme 调用 `vi_mode_prompt_info`，Starship 有原生 `[vi_mode]` 模块。键绑定现在就能用，只是没有视觉标识。已在 `docs/zsh.md` 的 Gotchas + Manual 小节里明注。