### PR TITLE
feat(starship): Mocha prompt with feedback modules, vi-mode cue, font pinning

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -35,6 +35,12 @@ brew "uv"
 # ---- Mac App Store CLI -----------------------------------------------------
 brew "mas"
 
+# ---- Fonts -----------------------------------------------------------------
+# NF variant is required by starship (powerline triangles + MDI glyphs like
+# the mac icon); CN variant covers CJK comments/messages. Terminal's
+# font-family needs to point at "Maple Mono NF CN".
+cask "font-maple-mono-nf-cn"
+
 # ---- GUI apps --------------------------------------------------------------
 cask "ghostty"
 cask "karabiner-elements"

--- a/docs/starship.md
+++ b/docs/starship.md
@@ -74,7 +74,7 @@ bash tests/starship.sh
 Open a new terminal tab:
 
 1. Prompt shows **two lines** — first line powerline segments, second line just `❯`.
-2. Nerd-font glyphs render as icons, not `□` boxes. If you see boxes, your terminal's font isn't a Nerd Font.
+2. Nerd-font glyphs render as icons (mac 󰀵, chat 󰭹, ✦), not `□` boxes. The Brewfile-pinned font is **Maple Mono NF CN**; if glyphs are boxes your terminal's `font-family` isn't pointing at it.
 3. `sleep 4` — line 2 should show yellow `took 4s`.
 4. `false` — line 2 should show red `✘ 1`.
 5. `sleep 100 &` — `$jobs` should show cyan `✦ 1`. `wait` or `kill %1` to clean up.
@@ -83,7 +83,7 @@ Open a new terminal tab:
 
 ## Troubleshooting
 
-**Nerd-font glyphs show as `□` boxes** — terminal font is missing. Ghostty ships with JetBrainsMono Nerd Font bundled (Phase 4b sets this); other terminals need `brew install --cask font-jetbrains-mono-nerd-font`.
+**Nerd-font glyphs show as `□` boxes** — terminal font isn't a Nerd Font. The Brewfile ships `font-maple-mono-nf-cn`; point your terminal's `font-family` at `Maple Mono NF CN`. Phase 4b wires this into Ghostty automatically; on stock Terminal.app or iTerm2 set it in preferences.
 
 **`$custom.claude` never fires inside Claude Code** — check `echo $CLAUDECODE` in the session. If empty, the parent Claude Code version is older than the `CLAUDECODE=1` injection (≥ 1.x). Workaround: add a second detection branch via `when = 'test -n "$CLAUDECODE" -o -n "$CLAUDE_CODE_ENTRYPOINT"'`.
 

--- a/docs/starship.md
+++ b/docs/starship.md
@@ -67,7 +67,7 @@ Append `$custom` to the `format` block once — it expands to every `[custom.*]`
 bash tests/starship.sh
 ```
 
-14 checks: starship on PATH, config file present, `starship print-config` parses, tools.zsh wires it, `starship prompt` renders clean + error states, each feedback module fires under the right input (`--status=1`, `--cmd-duration=5000`, `--jobs=1`, `CLAUDECODE=1`), and the live prompt output carries the Powerline/nerd-font codepoints — since PUA glyphs are invisible in most editors and got stripped three times during earlier rewrites.
+17 checks: starship on PATH, config file present, `starship print-config` parses, tools.zsh wires it, `starship prompt` renders clean + error states, each feedback module fires under the right input (`--status=1`, `--cmd-duration=5000`, `--jobs=1`, `CLAUDECODE=1`), live prompt output carries Powerline + macOS + arrow codepoints, and the config file still has the git/c/python Dev-Icon symbols — since PUA glyphs are invisible in most editors and got stripped four times during earlier rewrites.
 
 ### Manual (real TTY required)
 

--- a/docs/starship.md
+++ b/docs/starship.md
@@ -67,7 +67,7 @@ Append `$custom` to the `format` block once — it expands to every `[custom.*]`
 bash tests/starship.sh
 ```
 
-11 checks: starship on PATH, config file present, `starship print-config` parses, tools.zsh wires it, `starship prompt` renders clean + error states, each feedback module fires under the right input (`--status=1`, `--cmd-duration=5000`, `--jobs=1`, `CLAUDECODE=1`).
+14 checks: starship on PATH, config file present, `starship print-config` parses, tools.zsh wires it, `starship prompt` renders clean + error states, each feedback module fires under the right input (`--status=1`, `--cmd-duration=5000`, `--jobs=1`, `CLAUDECODE=1`), and the live prompt output carries the Powerline/nerd-font codepoints — since PUA glyphs are invisible in most editors and got stripped three times during earlier rewrites.
 
 ### Manual (real TTY required)
 

--- a/docs/starship.md
+++ b/docs/starship.md
@@ -1,0 +1,111 @@
+# Starship prompt
+
+> English · [中文](starship.zh.md)
+
+Cross-shell prompt written in Rust. We use it for: two-line powerline context, Catppuccin Mocha palette matching `$BAT_THEME`, vi-mode visual cue (paired with OMZP::vi-mode), and three feedback modules that only show when they matter.
+
+## How it works
+
+| Thing | Where | Note |
+|---|---|---|
+| Config | `~/.config/starship.toml` → source `dot_config/starship.toml` | Single file, chezmoi-managed. |
+| Shell init | `~/.config/zsh/tools.zsh` → `eval "$(starship init zsh)"` | Guarded by `$+commands[starship]`. |
+| Palette | `catppuccin_mocha` defined inline | Matches `BAT_THEME="Catppuccin Mocha"` in `env.zsh`. |
+
+## Prompt layout
+
+Two lines:
+
+    ╭─  bytedance  ~/.dotfiles   feat/starship  ✓    19:42  ╮
+    ╰─   ✘ 1 took 14s ✦ 2 󰭹 claude
+
+**Line 1 — context (powerline segments, always visible):**
+
+| Segment | What | Rationale |
+|---|---|---|
+| `$os` | OS icon | multi-platform cue (mac/linux). |
+| `$username` | user, only if ≠ default | `show_always = false` — spelling out `bytedance` on every line is noise. |
+| `$directory` | 3-level truncated path | substitutions render common dirs as nerd-font icons. |
+| `$git_branch + $git_status` | branch + dirty markers | single segment, one color — branch always fits on one glance. |
+| `$c + $python` | C / Python version | algo research stack. `$package` removed (node/rust noise). |
+| `$time` | `%R` wall clock | no tmux status bar, so prompt is where the clock lives. |
+
+**Line 2 — feedback (no background, visible only when triggered):**
+
+| Module | Fires when | Why |
+|---|---|---|
+| `$status` | last command exited non-zero | fail-loud instead of fail-quiet. |
+| `$cmd_duration` | last command ran ≥ 3s | training / OJ runs — "did this actually take that long?" without `time`. |
+| `$jobs` | ≥ 1 background job | `&`-launched training jobs stay visible. |
+| `$custom.claude` | `CLAUDECODE=1` is set | prompt in a shell spawned inside a Claude Code session is visually distinct. |
+| `$character` | always last | red on failure, green on success, mauve on vi-normal. |
+
+## Change a segment
+
+1. Find the segment in `dot_config/starship.toml` (grouped under `# ─── Context segments ───` and `# ─── Feedback modules ───`).
+2. Edit in place — no shell reload needed; starship re-reads config on every prompt.
+3. Add/remove from the top-level `format = """..."""` block to change left-to-right order or drop a segment entirely.
+
+## Add a custom module
+
+```toml
+[custom.mymodule]
+description = "..."
+when        = 'test -n "$SOME_ENV"'   # POSIX test, evaluated by /bin/sh
+command     = "echo"                   # empty stdout; format carries literal text
+format      = '[  mymodule ]($style)'
+style       = "bold fg:lavender"
+```
+
+Append `$custom` to the `format` block once — it expands to every `[custom.*]` module registered.
+
+## Health check
+
+### Automated
+
+```bash
+bash tests/starship.sh
+```
+
+11 checks: starship on PATH, config file present, `starship print-config` parses, tools.zsh wires it, `starship prompt` renders clean + error states, each feedback module fires under the right input (`--status=1`, `--cmd-duration=5000`, `--jobs=1`, `CLAUDECODE=1`).
+
+### Manual (real TTY required)
+
+Open a new terminal tab:
+
+1. Prompt shows **two lines** — first line powerline segments, second line just `❯`.
+2. Nerd-font glyphs render as icons, not `□` boxes. If you see boxes, your terminal's font isn't a Nerd Font.
+3. `sleep 4` — line 2 should show yellow `took 4s`.
+4. `false` — line 2 should show red `✘ 1`.
+5. `sleep 100 &` — `$jobs` should show cyan `✦ 1`. `wait` or `kill %1` to clean up.
+6. Inside Claude Code, `$CLAUDECODE=1` — line 2 should show mauve `󰭹 claude`.
+7. Press Esc after typing something — `❯` should turn mauve (vi-normal mode).
+
+## Troubleshooting
+
+**Nerd-font glyphs show as `□` boxes** — terminal font is missing. Ghostty ships with JetBrainsMono Nerd Font bundled (Phase 4b sets this); other terminals need `brew install --cask font-jetbrains-mono-nerd-font`.
+
+**`$custom.claude` never fires inside Claude Code** — check `echo $CLAUDECODE` in the session. If empty, the parent Claude Code version is older than the `CLAUDECODE=1` injection (≥ 1.x). Workaround: add a second detection branch via `when = 'test -n "$CLAUDECODE" -o -n "$CLAUDE_CODE_ENTRYPOINT"'`.
+
+**vi-mode indicator stuck on green after Esc** — OMZP::vi-mode didn't toggle `$KEYMAP`. Verify `zinit snippet OMZP::vi-mode` is loaded in `plugins.zsh` (sync, not Turbo — vi-mode needs to bind keys before the first prompt).
+
+**Color looks wrong** — `palette = 'catppuccin_mocha'` but a module references a name not in the palette. Starship silently falls back to default terminal foreground. Grep the config for suspect color names and cross-check against `[palettes.catppuccin_mocha]`.
+
+**`starship prompt` hangs in a script** — rare, but `$cmd_duration` or `$custom` can invoke slow subprocesses. Run `starship timings` in an interactive shell to spot the offender.
+
+## Gotchas
+
+**Starship init must come AFTER `OMZP::vi-mode`.** Order in `tools.zsh`: fzf → zoxide → starship; `plugins.zsh` loads vi-mode synchronously. If you flip the order, `vimcmd_symbol` binds to an uninitialised `$KEYMAP` and the indicator never switches.
+
+**Catppuccin color names are not universal.** Mocha does NOT define `orange` or `purple`. Old config had `orange = "#cba6f7"` (actually mauve's hex) and `bg:purple` references that silently fell back to terminal default. Fixed in this phase — if you add modules, reference names from `[palettes.catppuccin_mocha]` only.
+
+**`starship prompt` in a non-TTY returns ANSI codes, not glyphs.** The automated tests grep for literal `✘`, `took`, etc. — keep format strings using these markers or the tests break.
+
+## Rebuild from scratch
+
+```bash
+# Nothing to wipe — starship is stateless. Just re-apply config:
+chezmoi --source ~/.dotfiles apply
+```
+
+If `starship init zsh` stops firing, verify `starship` is on PATH (`brew install starship`) and `tools.zsh` still has the guarded block.

--- a/docs/starship.md
+++ b/docs/starship.md
@@ -67,7 +67,7 @@ Append `$custom` to the `format` block once — it expands to every `[custom.*]`
 bash tests/starship.sh
 ```
 
-17 checks: starship on PATH, config file present, `starship print-config` parses, tools.zsh wires it, `starship prompt` renders clean + error states, each feedback module fires under the right input (`--status=1`, `--cmd-duration=5000`, `--jobs=1`, `CLAUDECODE=1`), live prompt output carries Powerline + macOS + arrow codepoints, and the config file still has the git/c/python Dev-Icon symbols — since PUA glyphs are invisible in most editors and got stripped four times during earlier rewrites.
+20 checks: starship on PATH, config file present, `starship print-config` parses, tools.zsh wires it, `starship prompt` renders clean + error states, each feedback module fires under the right input (`--status=1`, `--cmd-duration=5000`, `--jobs=1`, `CLAUDECODE=1`), live prompt output carries Powerline + macOS + arrow codepoints, and the config file still has git / c / python / clock / Downloads / Pictures nerd-font glyphs — since PUA codepoints are invisible in most editors and got stripped five times during earlier rewrites.
 
 ### Manual (real TTY required)
 

--- a/docs/starship.zh.md
+++ b/docs/starship.zh.md
@@ -67,7 +67,7 @@ style       = "bold fg:lavender"
 bash tests/starship.sh
 ```
 
-14 条检查：starship 在 PATH、config 文件存在、`starship print-config` 解析、tools.zsh 接线成功、`starship prompt` 正常 + 异常都能渲染、每个反馈 module 在正确输入下 fire（`--status=1`、`--cmd-duration=5000`、`--jobs=1`、`CLAUDECODE=1`），以及 live prompt 输出里必须携带 Powerline / nerd-font 的 PUA 码点 —— 这些字形在大多数编辑器里隐形，早期重写时被静默吞掉过三次。
+17 条检查：starship 在 PATH、config 文件存在、`starship print-config` 解析、tools.zsh 接线成功、`starship prompt` 正常 + 异常都能渲染、每个反馈 module 在正确输入下 fire（`--status=1`、`--cmd-duration=5000`、`--jobs=1`、`CLAUDECODE=1`）、live prompt 输出携带 Powerline + macOS + arrow 码点，以及 config 文件里 git / c / python 的 Dev-Icon 符号依然在位 —— 这些 PUA 字形在大多数编辑器里隐形，早期重写时被静默吞掉过四次。
 
 ### 手动（需要真实 TTY）
 

--- a/docs/starship.zh.md
+++ b/docs/starship.zh.md
@@ -67,7 +67,7 @@ style       = "bold fg:lavender"
 bash tests/starship.sh
 ```
 
-11 条检查：starship 在 PATH、config 文件存在、`starship print-config` 解析、tools.zsh 接线成功、`starship prompt` 正常 + 异常都能渲染、每个反馈 module 在正确输入下 fire（`--status=1`、`--cmd-duration=5000`、`--jobs=1`、`CLAUDECODE=1`）。
+14 条检查：starship 在 PATH、config 文件存在、`starship print-config` 解析、tools.zsh 接线成功、`starship prompt` 正常 + 异常都能渲染、每个反馈 module 在正确输入下 fire（`--status=1`、`--cmd-duration=5000`、`--jobs=1`、`CLAUDECODE=1`），以及 live prompt 输出里必须携带 Powerline / nerd-font 的 PUA 码点 —— 这些字形在大多数编辑器里隐形，早期重写时被静默吞掉过三次。
 
 ### 手动（需要真实 TTY）
 

--- a/docs/starship.zh.md
+++ b/docs/starship.zh.md
@@ -67,7 +67,7 @@ style       = "bold fg:lavender"
 bash tests/starship.sh
 ```
 
-17 条检查：starship 在 PATH、config 文件存在、`starship print-config` 解析、tools.zsh 接线成功、`starship prompt` 正常 + 异常都能渲染、每个反馈 module 在正确输入下 fire（`--status=1`、`--cmd-duration=5000`、`--jobs=1`、`CLAUDECODE=1`）、live prompt 输出携带 Powerline + macOS + arrow 码点，以及 config 文件里 git / c / python 的 Dev-Icon 符号依然在位 —— 这些 PUA 字形在大多数编辑器里隐形，早期重写时被静默吞掉过四次。
+20 条检查：starship 在 PATH、config 文件存在、`starship print-config` 解析、tools.zsh 接线成功、`starship prompt` 正常 + 异常都能渲染、每个反馈 module 在正确输入下 fire（`--status=1`、`--cmd-duration=5000`、`--jobs=1`、`CLAUDECODE=1`）、live prompt 输出携带 Powerline + macOS + arrow 码点，以及 config 文件里 git / c / python / 时钟 / Downloads / Pictures 的 nerd-font 字形依然在位 —— 这些 PUA 码点在大多数编辑器里隐形，早期重写时被静默吞掉过五次。
 
 ### 手动（需要真实 TTY）
 

--- a/docs/starship.zh.md
+++ b/docs/starship.zh.md
@@ -74,7 +74,7 @@ bash tests/starship.sh
 开新 terminal tab：
 
 1. Prompt 是**两行** —— 第一行 powerline 段，第二行只有 `❯`。
-2. Nerd-font 字形渲成图标，不是 `□` 方框。如果看到方框，你终端字体不是 Nerd Font。
+2. Nerd-font 字形渲成图标（mac 󰀵、chat 󰭹、✦ 等），不是 `□` 方框。Brewfile 锁的字体是 **Maple Mono NF CN**；若看到方框，说明终端 `font-family` 没指向它。
 3. `sleep 4` —— 第二行应显示黄色 `took 4s`。
 4. `false` —— 第二行应显示红色 `✘ 1`。
 5. `sleep 100 &` —— `$jobs` 应显示青色 `✦ 1`；用 `wait` 或 `kill %1` 清理。
@@ -83,7 +83,7 @@ bash tests/starship.sh
 
 ## Troubleshooting
 
-**Nerd-font 字形显示为 `□` 方框** —— 终端字体缺失。Ghostty 自带 JetBrainsMono Nerd Font（Phase 4b 配置）；其他终端需 `brew install --cask font-jetbrains-mono-nerd-font`。
+**Nerd-font 字形显示为 `□` 方框** —— 终端字体不是 Nerd Font。Brewfile 锁了 `font-maple-mono-nf-cn`，把终端的 `font-family` 指到 `Maple Mono NF CN`。Phase 4b 会自动写进 Ghostty；Terminal.app / iTerm2 需要在偏好设置里手动选。
 
 **在 Claude Code 里 `$custom.claude` 不显示** —— `echo $CLAUDECODE` 检查一下。如果空，父进程 Claude Code 版本太老没注入（≥ 1.x 才有）。兜底方案：`when = 'test -n "$CLAUDECODE" -o -n "$CLAUDE_CODE_ENTRYPOINT"'`。
 

--- a/docs/starship.zh.md
+++ b/docs/starship.zh.md
@@ -1,0 +1,111 @@
+# Starship prompt
+
+> [English](starship.md) · 中文
+
+Rust 写的跨 shell prompt。我们用它做：双行 powerline 上下文、Catppuccin Mocha 色板（与 `$BAT_THEME` 一致）、vi-mode 视觉反馈（配合 OMZP::vi-mode），以及三个"只在需要时出现"的反馈 module。
+
+## How it works
+
+| 东西 | 位置 | 说明 |
+|---|---|---|
+| 配置 | `~/.config/starship.toml` ← 源 `dot_config/starship.toml` | 单文件，chezmoi 管 |
+| shell 初始化 | `~/.config/zsh/tools.zsh` → `eval "$(starship init zsh)"` | 用 `$+commands[starship]` 做守卫 |
+| 色板 | 内联定义的 `catppuccin_mocha` | 与 `env.zsh` 里 `BAT_THEME="Catppuccin Mocha"` 对齐 |
+
+## Prompt 布局
+
+两行：
+
+    ╭─  bytedance  ~/.dotfiles   feat/starship  ✓    19:42  ╮
+    ╰─   ✘ 1 took 14s ✦ 2 󰭹 claude
+
+**第 1 行 —— 上下文（powerline 段，始终可见）：**
+
+| 段 | 内容 | 理由 |
+|---|---|---|
+| `$os` | 系统图标 | 跨平台提示（mac / linux） |
+| `$username` | 非默认用户才显示 | `show_always = false` —— 单人 mac 每行挂 `bytedance` 是噪音 |
+| `$directory` | 3 级截断路径 | substitutions 把常用目录渲成 nerd-font 图标 |
+| `$git_branch + $git_status` | 分支 + dirty 标记 | 一段一色 —— 瞟一眼就知道分支状态 |
+| `$c + $python` | C / Python 版本 | 算法研究栈。`$package` 删掉了（node / rust 噪音） |
+| `$time` | `%R` 时钟 | 没有 tmux status bar，prompt 就是时钟位置 |
+
+**第 2 行 —— 反馈（无背景，只在触发时出现）：**
+
+| Module | 触发条件 | 理由 |
+|---|---|---|
+| `$status` | 上条命令 exit ≠ 0 | fail-loud，不要静默失败 |
+| `$cmd_duration` | 上条命令 ≥ 3s | 训练 / OJ run —— 不用 `time` 就知道"这条真的跑了这么久？" |
+| `$jobs` | 至少一个后台任务 | `&` 启的训练任务一直可见 |
+| `$custom.claude` | `CLAUDECODE=1` | 在 Claude Code session 内部开的 shell 视觉上可区分 |
+| `$character` | 永远最后 | 失败红、成功绿、vi-normal 紫 |
+
+## 改段
+
+1. 在 `dot_config/starship.toml` 找到段（按 `# ─── Context segments ───` / `# ─── Feedback modules ───` 分组）。
+2. 直接改 —— 不用 reload shell，starship 每次渲染都重读配置。
+3. 要改左右顺序或删段，改顶层 `format = """..."""` 块。
+
+## 加一个 custom module
+
+```toml
+[custom.mymodule]
+description = "..."
+when        = 'test -n "$SOME_ENV"'   # POSIX test，由 /bin/sh 跑
+command     = "echo"                   # stdout 空，format 里写死文本
+format      = '[  mymodule ]($style)'
+style       = "bold fg:lavender"
+```
+
+`format` 顶层块里写一次 `$custom` 就够 —— 它会展开所有注册过的 `[custom.*]` module。
+
+## 健康检查
+
+### 自动化
+
+```bash
+bash tests/starship.sh
+```
+
+11 条检查：starship 在 PATH、config 文件存在、`starship print-config` 解析、tools.zsh 接线成功、`starship prompt` 正常 + 异常都能渲染、每个反馈 module 在正确输入下 fire（`--status=1`、`--cmd-duration=5000`、`--jobs=1`、`CLAUDECODE=1`）。
+
+### 手动（需要真实 TTY）
+
+开新 terminal tab：
+
+1. Prompt 是**两行** —— 第一行 powerline 段，第二行只有 `❯`。
+2. Nerd-font 字形渲成图标，不是 `□` 方框。如果看到方框，你终端字体不是 Nerd Font。
+3. `sleep 4` —— 第二行应显示黄色 `took 4s`。
+4. `false` —— 第二行应显示红色 `✘ 1`。
+5. `sleep 100 &` —— `$jobs` 应显示青色 `✦ 1`；用 `wait` 或 `kill %1` 清理。
+6. 在 Claude Code 里 `$CLAUDECODE=1` —— 第二行应显示紫色 `󰭹 claude`。
+7. 键入后按 Esc —— `❯` 应变紫色（vi-normal 模式）。
+
+## Troubleshooting
+
+**Nerd-font 字形显示为 `□` 方框** —— 终端字体缺失。Ghostty 自带 JetBrainsMono Nerd Font（Phase 4b 配置）；其他终端需 `brew install --cask font-jetbrains-mono-nerd-font`。
+
+**在 Claude Code 里 `$custom.claude` 不显示** —— `echo $CLAUDECODE` 检查一下。如果空，父进程 Claude Code 版本太老没注入（≥ 1.x 才有）。兜底方案：`when = 'test -n "$CLAUDECODE" -o -n "$CLAUDE_CODE_ENTRYPOINT"'`。
+
+**vi-mode 指示按 Esc 后卡在绿色** —— OMZP::vi-mode 没切换 `$KEYMAP`。查 `plugins.zsh` 里 `zinit snippet OMZP::vi-mode` 是否还在（同步加载，不走 Turbo —— vi-mode 得在第一个 prompt 之前绑好按键）。
+
+**颜色看起来不对** —— `palette = 'catppuccin_mocha'` 但某段引用了色板里没有的名字。Starship 会静默回退到终端默认前景。grep 配置里可疑的颜色名，对比 `[palettes.catppuccin_mocha]`。
+
+**`starship prompt` 在脚本里卡住** —— 少见，但 `$cmd_duration` 或 `$custom` 可能调起慢子进程。交互 shell 里跑 `starship timings` 看是谁。
+
+## Gotchas
+
+**Starship init 必须在 `OMZP::vi-mode` 之后。** `tools.zsh` 顺序：fzf → zoxide → starship；`plugins.zsh` 同步加载 vi-mode。顺序反了 `vimcmd_symbol` 会绑到未初始化的 `$KEYMAP`，指示永远不切。
+
+**Catppuccin 的颜色名不通用。** Mocha **没有** `orange` 也**没有** `purple`。旧配置里 `orange = "#cba6f7"`（其实是 mauve 的 hex）和 `bg:purple` 都是坏的，静默回退到终端默认。本 phase 修复了 —— 加 module 时只引用 `[palettes.catppuccin_mocha]` 里存在的名字。
+
+**`starship prompt` 在非 TTY 下输出的是 ANSI code 不是字形。** 自动化测试 grep 的是字面 `✘`、`took` 等字符，格式串改了就得同步改测试。
+
+## 从零重建
+
+```bash
+# 没东西要清 —— starship 无状态。重新 apply 即可：
+chezmoi --source ~/.dotfiles apply
+```
+
+`starship init zsh` 没执行？先确认 starship 在 PATH 上（`brew install starship`），再确认 `tools.zsh` 里带守卫的那块还在。

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -90,7 +90,7 @@ Turbo plugins load on the `precmd` hook, so `zsh -i -c '...'` or scripted shells
 1. Type `git sta` — "tus" should appear as grey inline suggestion (autosuggestions).
 2. Type `ls` — the command should render colored (green/cyan), not plain white (syntax-highlighting).
 3. Press Tab on an empty `git ` — fzf-style menu should appear (fzf-tab).
-4. Press Esc — right side of prompt should show `[NORMAL]`. *Phase 3 caveat: this requires a prompt theme that calls `vi_mode_prompt_info`. Starship (Phase 4) covers this; until then bindings work but the indicator is invisible.*
+4. Press Esc — `character` symbol should turn mauve (starship `[character].vimcmd_symbol`). See [starship.md](starship.md) for the detail.
 
 ## Startup perf
 
@@ -139,7 +139,7 @@ zinit report author/plugin-name
 
 **First `chezmoi apply` downloads all plugins — expect 30-60s.** Subsequent applies are instant. If it looks hung, it's pulling from GitHub.
 
-**Prompt has no vi-mode indicator until Phase 4.** OMZP::vi-mode defines `vi_mode_prompt_info` but relies on the theme to call it. Bindings work; the visual `[NORMAL]` lands with Starship.
+**vi-mode visual cue is rendered by starship, not zsh.** OMZP::vi-mode defines `vi_mode_prompt_info` and flips `$KEYMAP`; the visible indicator comes from starship's `[character].vimcmd_symbol`. See [starship.md](starship.md).
 
 ## Rebuild from scratch
 

--- a/docs/zsh.zh.md
+++ b/docs/zsh.zh.md
@@ -90,7 +90,7 @@ Turbo 插件靠 `precmd` hook 触发，`zsh -i -c '...'` 或 script 子进程压
 1. 敲 `git sta` —— "tus" 应以灰色行内建议出现（autosuggestions）。
 2. 敲 `ls` —— 命令本身应着色（绿/青），而非纯白（syntax-highlighting）。
 3. 在空 `git ` 后按 Tab —— 应弹出 fzf 风格菜单（fzf-tab）。
-4. 按 Esc —— 右侧 prompt 应显示 `[NORMAL]`。*Phase 3 局限：需要 prompt theme 调用 `vi_mode_prompt_info`，等 Phase 4 Starship 落地才能看到；Phase 3 内键绑定能用但指示器隐形。*
+4. 按 Esc —— `character` 符号应变 mauve 色（starship `[character].vimcmd_symbol`），详见 [starship.zh.md](starship.zh.md)。
 
 ## 启动性能
 
@@ -139,7 +139,7 @@ zinit report author/plugin-name
 
 **首次 `chezmoi apply` 下载所有 plugin 30-60s 属正常。** 之后都是秒级。看起来卡住是在从 GitHub 拉。
 
-**Phase 4 之前 prompt 没 vi-mode 指示器。** OMZP::vi-mode 定义 `vi_mode_prompt_info` 但依赖 prompt theme 调用它。键绑定现在可用；`[NORMAL]` 要等 Starship。
+**vi-mode 视觉提示由 starship 渲染，不由 zsh。** OMZP::vi-mode 定义 `vi_mode_prompt_info` 并切换 `$KEYMAP`；真正显示的指示是 starship 的 `[character].vimcmd_symbol`，详见 [starship.zh.md](starship.zh.md)。
 
 ## 彻底重建
 

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -92,19 +92,18 @@ truncation_symbol = "…/"
 "Developer" = "󰲋 "
 
 [git_branch]
-symbol = ""
+symbol = ""
 format = '[ $symbol $branch ](fg:base bg:green)'
 
 [git_status]
 format = '[($all_status$ahead_behind )](fg:base bg:green)'
 
 [c]
-symbol = " "
+symbol = " "
 format = '[ $symbol( $version) ](fg:base bg:green)'
 
 [python]
-symbol = ""
-pyenv_version_name = true
+symbol = ""
 format = '[ $symbol( ${version})(\($virtualenv\)) ](fg:base bg:green)'
 
 [time]

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -60,6 +60,10 @@ crust = "#11111b"
 [os]
 disabled = false
 style = "bg:surface0 fg:text"
+# Explicit padding — previous config relied on $username (show_always=true)
+# to pad this segment. With $username off, the icon would sit flush against
+# the transition triangle and look undersized.
+format = "[ $symbol ]($style)"
 
 [os.symbols]
 Macos = "󰀵"

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -15,16 +15,17 @@ $directory\
 [](fg:peach bg:green)\
 $git_branch\
 $git_status\
+[](fg:green bg:teal)\
 $c\
 $python\
-[](fg:green bg:mauve)\
+[](fg:teal bg:mauve)\
 $time\
-[ ](fg:mauve)\
-$line_break\
 $status\
 $cmd_duration\
 $jobs\
 $custom\
+[ ](fg:mauve)\
+$line_break\
 $character"""
 
 [palettes.catppuccin_mocha]
@@ -100,11 +101,11 @@ format = '[($all_status$ahead_behind )](fg:base bg:green)'
 
 [c]
 symbol = " "
-format = '[ $symbol( $version) ](fg:base bg:green)'
+format = '[ $symbol( $version) ](fg:base bg:teal)'
 
 [python]
 symbol = ""
-format = '[ $symbol( ${version})(\($virtualenv\)) ](fg:base bg:green)'
+format = '[ $symbol( ${version})(\($virtualenv\)) ](fg:base bg:teal)'
 
 [time]
 disabled = false
@@ -120,20 +121,20 @@ disabled = false
 disabled = false
 symbol = "✘ "
 format = '[$symbol$common_meaning$signal_name$maybe_int ]($style)'
-style = "bold fg:red"
+style = "bold fg:red bg:mauve"
 map_symbol = true
 
 [cmd_duration]
 # Only show when the previous command ran ≥ 3s — signal, not noise.
 min_time = 3_000
 format = '[took $duration ]($style)'
-style = "fg:yellow"
+style = "fg:mantle bg:mauve"
 
 [jobs]
 symbol = "✦ "
 number_threshold = 1
 format = '[$symbol$number ]($style)'
-style = "fg:sapphire"
+style = "fg:sapphire bg:mauve"
 
 [custom.claude]
 # Active when $CLAUDECODE=1 is injected by a Claude Code session, so the
@@ -142,7 +143,7 @@ description = "Claude Code session indicator"
 when = 'test -n "$CLAUDECODE"'
 command = "echo"
 format = '[󰭹 claude ]($style)'
-style = "bold fg:lavender"
+style = "bold fg:lavender bg:mauve"
 
 [character]
 success_symbol = '[](bold fg:green)'

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -15,10 +15,9 @@ $directory\
 [](fg:peach bg:green)\
 $git_branch\
 $git_status\
-[](fg:green bg:teal)\
 $c\
 $python\
-[](fg:teal bg:mauve)\
+[](fg:green bg:mauve)\
 $time\
 [ ](fg:mauve)\
 $line_break\
@@ -97,12 +96,12 @@ format = '[($all_status$ahead_behind )](fg:base bg:green)'
 
 [c]
 symbol = " "
-format = '[ $symbol( $version) ](fg:base bg:teal)'
+format = '[ $symbol( $version) ](fg:base bg:green)'
 
 [python]
 symbol = ""
 pyenv_version_name = true
-format = '[ $symbol( ${version})(\($virtualenv\)) ](fg:base bg:teal)'
+format = '[ $symbol( ${version})(\($virtualenv\)) ](fg:base bg:green)'
 
 [time]
 disabled = false
@@ -143,9 +142,9 @@ format = '[󰭹 claude ]($style)'
 style = "bold fg:lavender"
 
 [character]
-success_symbol = '[](bold fg:green)'
-error_symbol = '[](bold fg:red)'
-vimcmd_symbol = '[](bold fg:green)'
-vimcmd_replace_one_symbol = '[](bold fg:mauve)'
-vimcmd_replace_symbol = '[](bold fg:mauve)'
-vimcmd_visual_symbol = '[](bold fg:lavender)'
+success_symbol = '[](bold fg:green)'
+error_symbol = '[](bold fg:red)'
+vimcmd_symbol = '[](bold fg:green)'
+vimcmd_replace_one_symbol = '[](bold fg:mauve)'
+vimcmd_replace_symbol = '[](bold fg:mauve)'
+vimcmd_visual_symbol = '[](bold fg:lavender)'

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -87,9 +87,9 @@ truncation_symbol = "…/"
 
 [directory.substitutions]
 "Documents" = "󰈙 "
-"Downloads" = " "
+"Downloads" = " "
 "Music" = "󰝚 "
-"Pictures" = " "
+"Pictures" = " "
 "Developer" = "󰲋 "
 
 [git_branch]
@@ -110,7 +110,7 @@ format = '[ $symbol( ${version})(\($virtualenv\)) ](fg:base bg:teal)'
 [time]
 disabled = false
 time_format = "%R"
-format = '[  $time ](fg:mantle bg:mauve)'
+format = '[  $time ](fg:mantle bg:mauve)'
 
 [line_break]
 disabled = false

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -1,0 +1,151 @@
+"$schema" = 'https://starship.rs/config-schema.json'
+
+# Catppuccin Mocha palette — matches $BAT_THEME for repo-wide color consistency.
+palette = 'catppuccin_mocha'
+
+# Prompt layout:
+#   line 1 — context segments (powerline): os · user · dir · git · lang · time
+#   line 2 — feedback (no bg, invisible when idle): status · cmd_duration · jobs · claude · character
+format = """
+[](surface0)\
+$os\
+$username\
+[](bg:peach fg:surface0)\
+$directory\
+[](fg:peach bg:green)\
+$git_branch\
+$git_status\
+[](fg:green bg:teal)\
+$c\
+$python\
+[](fg:teal bg:mauve)\
+$time\
+[ ](fg:mauve)\
+$line_break\
+$status\
+$cmd_duration\
+$jobs\
+$custom\
+$character"""
+
+[palettes.catppuccin_mocha]
+rosewater = "#f5e0dc"
+flamingo = "#f2cdcd"
+pink = "#f5c2e7"
+mauve = "#cba6f7"
+red = "#f38ba8"
+maroon = "#eba0ac"
+peach = "#fab387"
+yellow = "#f9e2af"
+green = "#a6e3a1"
+teal = "#94e2d5"
+sky = "#89dceb"
+sapphire = "#74c7ec"
+blue = "#89b4fa"
+lavender = "#b4befe"
+text = "#cdd6f4"
+subtext1 = "#bac2de"
+subtext0 = "#a6adc8"
+overlay2 = "#9399b2"
+overlay1 = "#7f849c"
+overlay0 = "#6c7086"
+surface2 = "#585b70"
+surface1 = "#45475a"
+surface0 = "#313244"
+base = "#1e1e2e"
+mantle = "#181825"
+crust = "#11111b"
+
+# ─── Context segments ────────────────────────────────────────────────
+
+[os]
+disabled = false
+style = "bg:surface0 fg:text"
+
+[os.symbols]
+Macos = "󰀵"
+Linux = "󰌽"
+Ubuntu = "󰕈"
+
+[username]
+# Only show when user ≠ default (ssh, su, root). Single-person laptop has
+# no need to spell out `bytedance` on every prompt line.
+show_always = false
+style_user = "bg:surface0 fg:text"
+style_root = "bg:surface0 fg:red"
+format = '[ $user ]($style)'
+
+[directory]
+format = "[ $path ]($style)"
+style = "fg:mantle bg:peach"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = "󰝚 "
+"Pictures" = " "
+"Developer" = "󰲋 "
+
+[git_branch]
+symbol = ""
+format = '[ $symbol $branch ](fg:base bg:green)'
+
+[git_status]
+format = '[($all_status$ahead_behind )](fg:base bg:green)'
+
+[c]
+symbol = " "
+format = '[ $symbol( $version) ](fg:base bg:teal)'
+
+[python]
+symbol = ""
+pyenv_version_name = true
+format = '[ $symbol( ${version})(\($virtualenv\)) ](fg:base bg:teal)'
+
+[time]
+disabled = false
+time_format = "%R"
+format = '[  $time ](fg:mantle bg:mauve)'
+
+[line_break]
+disabled = false
+
+# ─── Feedback modules (shown only when triggered) ────────────────────
+
+[status]
+disabled = false
+symbol = "✘ "
+format = '[$symbol$common_meaning$signal_name$maybe_int ]($style)'
+style = "bold fg:red"
+map_symbol = true
+
+[cmd_duration]
+# Only show when the previous command ran ≥ 3s — signal, not noise.
+min_time = 3_000
+format = '[took $duration ]($style)'
+style = "fg:yellow"
+
+[jobs]
+symbol = "✦ "
+number_threshold = 1
+format = '[$symbol$number ]($style)'
+style = "fg:sapphire"
+
+[custom.claude]
+# Active when $CLAUDECODE=1 is injected by a Claude Code session, so the
+# prompt in any nested shell makes it obvious the parent is an AI agent.
+description = "Claude Code session indicator"
+when = 'test -n "$CLAUDECODE"'
+command = "echo"
+format = '[󰭹 claude ]($style)'
+style = "bold fg:lavender"
+
+[character]
+success_symbol = '[](bold fg:green)'
+error_symbol = '[](bold fg:red)'
+vimcmd_symbol = '[](bold fg:green)'
+vimcmd_replace_one_symbol = '[](bold fg:mauve)'
+vimcmd_replace_symbol = '[](bold fg:mauve)'
+vimcmd_visual_symbol = '[](bold fg:lavender)'

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -7,20 +7,20 @@ palette = 'catppuccin_mocha'
 #   line 1 — context segments (powerline): os · user · dir · git · lang · time
 #   line 2 — feedback (no bg, invisible when idle): status · cmd_duration · jobs · claude · character
 format = """
-[](surface0)\
+[](surface0)\
 $os\
 $username\
-[](bg:peach fg:surface0)\
+[](bg:peach fg:surface0)\
 $directory\
-[](fg:peach bg:green)\
+[](fg:peach bg:green)\
 $git_branch\
 $git_status\
-[](fg:green bg:teal)\
+[](fg:green bg:teal)\
 $c\
 $python\
-[](fg:teal bg:mauve)\
+[](fg:teal bg:mauve)\
 $time\
-[ ](fg:mauve)\
+[ ](fg:mauve)\
 $line_break\
 $status\
 $cmd_duration\

--- a/dot_config/zsh/env.zsh
+++ b/dot_config/zsh/env.zsh
@@ -9,8 +9,8 @@ elif [[ -x /usr/local/bin/brew ]]; then
     eval "$(/usr/local/bin/brew shellenv)"
 fi
 
-# bat color theme
-export BAT_THEME="Catppuccin Frappe"
+# bat color theme — matches starship palette (catppuccin_mocha) for repo-wide consistency.
+export BAT_THEME="Catppuccin Mocha"
 
 # Hugging Face mirror (大陆网络)
 export HF_ENDPOINT="https://hf-mirror.com"

--- a/dot_config/zsh/tools.zsh
+++ b/dot_config/zsh/tools.zsh
@@ -15,3 +15,9 @@ fi
 if (( $+commands[zoxide] )); then
     eval "$(zoxide init zsh)"
 fi
+
+# starship: prompt. Must init AFTER plugins.zsh so OMZP::vi-mode's
+# KEYMAP hook is in place — otherwise `vimcmd_symbol` won't fire on Esc.
+if (( $+commands[starship] )); then
+    eval "$(starship init zsh)"
+fi

--- a/tests/starship.sh
+++ b/tests/starship.sh
@@ -47,6 +47,27 @@ check 'custom.claude hidden without CLAUDECODE'  '[[ "$PROMPT_NO_CLAUDE" != *cla
 check 'custom.claude visible with CLAUDECODE=1'  '[[ "$PROMPT_CLAUDE" == *claude* ]]'
 
 echo
+echo "── Nerd-font / Powerline glyph invariants ───────────"
+# These codepoints live in the Private Use Area. They are invisible to
+# most text editors and were silently stripped three times during earlier
+# refactors, yielding a visually broken prompt while every other check
+# passed. Count them from the live render so the failure can't hide again.
+PUA_COUNTS=$(starship prompt 2>/dev/null | python3 -c '
+import sys, re
+raw = sys.stdin.buffer.read().decode("utf-8", errors="replace")
+txt = re.sub(r"\x1b\[[0-9;]*m", "", raw)
+pl = sum(1 for c in txt if 0xE0B0 <= ord(c) <= 0xE0BF)
+mac = sum(1 for c in txt if ord(c) == 0xF0035)
+arrow = sum(1 for c in txt if ord(c) == 0xF432)
+print(f"{pl} {mac} {arrow}")
+')
+read PL MAC ARROW <<<"$PUA_COUNTS"
+export PL MAC ARROW
+check 'Powerline glyphs in prompt (≥5)'          '(( PL >= 5 ))'
+check 'macOS nerd-font icon (U+F0035) present'   '(( MAC >= 1 ))'
+check 'character arrow glyph (U+F432) present'   '(( ARROW >= 1 ))'
+
+echo
 echo "─────────────────────────────────────────────────────"
 if (( FAIL > 0 )); then
     printf "  \033[31m%d passed, %d failed\033[0m\n" $PASS $FAIL

--- a/tests/starship.sh
+++ b/tests/starship.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Non-interactive starship health check. ~1s. Covers everything testable
+# without a real TTY — powerline glyph rendering, nerd-font fallback, and
+# actual color output live in docs/starship.md → Health check → Manual.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$1"; PASS=$((PASS+1)); }
+bad() { printf "  \033[31m✗\033[0m %s\n" "$1"; [[ -n ${2:-} ]] && printf "    %s\n" "$2"; FAIL=$((FAIL+1)); }
+
+check() {
+    local name=$1 cmd=$2 out
+    if out=$(eval "$cmd" 2>&1); then ok "$name"; else bad "$name" "$out"; fi
+}
+
+echo "── File presence ────────────────────────────────────"
+check "starship on PATH"                         "command -v starship >/dev/null"
+check "~/.config/starship.toml"                  "test -r ~/.config/starship.toml"
+
+echo
+echo "── Config parses ────────────────────────────────────"
+check "starship print-config exits 0"            "starship print-config >/dev/null"
+
+echo
+echo "── zsh integration wired ────────────────────────────"
+check "tools.zsh invokes 'starship init zsh'"    "grep -q 'starship init zsh' ~/.config/zsh/tools.zsh"
+
+echo
+echo "── Prompt renders ───────────────────────────────────"
+check "starship prompt (clean)"                  "starship prompt >/dev/null"
+check "starship prompt --status 1 (error)"       "starship prompt --status 1 >/dev/null"
+
+echo
+echo "── Feedback modules fire under correct conditions ───"
+PROMPT_ERR=$(starship prompt --status=1 2>/dev/null || true)
+PROMPT_LONG=$(starship prompt --cmd-duration=5000 2>/dev/null || true)
+PROMPT_JOB=$(starship prompt --jobs=1 2>/dev/null || true)
+PROMPT_NO_CLAUDE=$(env -u CLAUDECODE starship prompt 2>/dev/null || true)
+PROMPT_CLAUDE=$(CLAUDECODE=1 starship prompt 2>/dev/null || true)
+export PROMPT_ERR PROMPT_LONG PROMPT_JOB PROMPT_NO_CLAUDE PROMPT_CLAUDE
+
+check '$status shows ✘ on exit 1'                '[[ "$PROMPT_ERR" == *✘* ]]'
+check '$cmd_duration shows "took" after ≥3s'     '[[ "$PROMPT_LONG" == *took* ]]'
+check '$jobs shows ✦ when a bg job exists'       '[[ "$PROMPT_JOB" == *✦* ]]'
+check 'custom.claude hidden without CLAUDECODE'  '[[ "$PROMPT_NO_CLAUDE" != *claude* ]]'
+check 'custom.claude visible with CLAUDECODE=1'  '[[ "$PROMPT_CLAUDE" == *claude* ]]'
+
+echo
+echo "─────────────────────────────────────────────────────"
+if (( FAIL > 0 )); then
+    printf "  \033[31m%d passed, %d failed\033[0m\n" $PASS $FAIL
+    echo
+    echo "  Visual fidelity (nerd-font glyphs, powerline segments,"
+    echo "  actual colors) is NOT covered here — open a real terminal"
+    echo "  and run the Manual checklist in docs/starship.md."
+    exit 1
+fi
+printf "  \033[32m%d passed, %d failed\033[0m\n" $PASS $FAIL
+echo
+echo "  Config + module logic OK. Visual rendering still needs a real"
+echo "  TTY — see docs/starship.md → Health check → Manual."

--- a/tests/starship.sh
+++ b/tests/starship.sh
@@ -75,6 +75,9 @@ export STARSHIP_CFG
 check '[git_branch] symbol U+F418 in config'     'has_cp F418 "$STARSHIP_CFG"'
 check '[c] symbol U+E61E in config'              'has_cp E61E "$STARSHIP_CFG"'
 check '[python] symbol U+E606 in config'         'has_cp E606 "$STARSHIP_CFG"'
+check '[time] clock icon U+F43A in config'       'has_cp F43A "$STARSHIP_CFG"'
+check 'Downloads dir icon U+F019 in config'      'has_cp F019 "$STARSHIP_CFG"'
+check 'Pictures dir icon U+F03E in config'       'has_cp F03E "$STARSHIP_CFG"'
 
 echo
 echo "─────────────────────────────────────────────────────"

--- a/tests/starship.sh
+++ b/tests/starship.sh
@@ -49,9 +49,11 @@ check 'custom.claude visible with CLAUDECODE=1'  '[[ "$PROMPT_CLAUDE" == *claude
 echo
 echo "── Nerd-font / Powerline glyph invariants ───────────"
 # These codepoints live in the Private Use Area. They are invisible to
-# most text editors and were silently stripped three times during earlier
+# most text editors and were silently stripped four times during earlier
 # refactors, yielding a visually broken prompt while every other check
-# passed. Count them from the live render so the failure can't hide again.
+# passed. Count from the live render for what's always visible, and grep
+# the config file for conditional symbols (git/c/python) that only fire
+# in matching projects.
 PUA_COUNTS=$(starship prompt 2>/dev/null | python3 -c '
 import sys, re
 raw = sys.stdin.buffer.read().decode("utf-8", errors="replace")
@@ -66,6 +68,13 @@ export PL MAC ARROW
 check 'Powerline glyphs in prompt (≥5)'          '(( PL >= 5 ))'
 check 'macOS nerd-font icon (U+F0035) present'   '(( MAC >= 1 ))'
 check 'character arrow glyph (U+F432) present'   '(( ARROW >= 1 ))'
+STARSHIP_CFG="$HOME/.config/starship.toml"
+has_cp() { python3 -c 'import sys; sys.exit(0 if chr(int(sys.argv[1],16)) in open(sys.argv[2]).read() else 1)' "$1" "$2"; }
+export -f has_cp
+export STARSHIP_CFG
+check '[git_branch] symbol U+F418 in config'     'has_cp F418 "$STARSHIP_CFG"'
+check '[c] symbol U+E61E in config'              'has_cp E61E "$STARSHIP_CFG"'
+check '[python] symbol U+E606 in config'         'has_cp E606 "$STARSHIP_CFG"'
 
 echo
 echo "─────────────────────────────────────────────────────"


### PR DESCRIPTION
## Summary / 概述

Phase 4a lands a `catppuccin_mocha` starship prompt that fixes every latent bug in the old `~/dotfiles_bk/starship/.config/starship.toml`, adds four high-signal feedback modules, closes the Phase 3 `[NORMAL]` vi-mode gap, and pins a Nerd Font so the prompt actually renders. Nine commits on the branch — six of them fixes for invisible PUA codepoints that got silently stripped round after round during the initial rewrite; the commit history is the forensic trail.

## Change type / 变更类型

- [x] `feat` — new package / functionality

(Label is `feat` only. Intra-branch `fix` commits repaired regressions I introduced during this very rewrite, not bugs against `main`; `docs` + `test` are part of the phase three-part delivery convention, not standalone intent.)

## What shipped

**Config (`dot_config/starship.toml`)**
- Catppuccin Mocha palette, aligned with `BAT_THEME="Catppuccin Mocha"` (bumped in `env.zsh`)
- Two-line layout: line 1 powerline segments (`os · dir · git · c/python · time + feedback`), line 2 just `$character`
- Feedback modules render inline on the mauve time segment, invisible when idle:
  - `$status` — ✘ + exit code, red, fires on non-zero
  - `$cmd_duration` — "took Ns", fires ≥ 3s (researcher-friendly — training / OJ runs)
  - `$jobs` — ✦ + count, fires when a `&`-launched job exists
  - `[custom.claude]` — 󰭹 claude, fires when `$CLAUDECODE=1` is injected by a Claude Code session
- Fixed bugs carried over from the old config: `creen` typo that silently broke `vimcmd_symbol`, undefined `purple` palette ref, stray `orange = mauve-hex` entry
- Dropped `$package` (node/rust noise, irrelevant to the Python + C++ stack) and `$username.show_always` (single-person Mac)
- `[os]` now has its own `format = "[ $symbol ]($style)"` so the mac icon breathes without depending on `$username`

**Shell integration (`dot_config/zsh/tools.zsh`)**
- `eval "$(starship init zsh)"` guarded by `$+commands[starship]`
- Must init AFTER `OMZP::vi-mode` so `vimcmd_symbol` hooks into a ready `$KEYMAP` — documented as a gotcha

**Font (`Brewfile`)**
- New `# ---- Fonts ----` section, `cask "font-maple-mono-nf-cn"` — NF covers powerline + MDI glyphs, CN covers CJK comments

**Tests (`tests/starship.sh`)**
- 20 checks: starship on PATH, config parses, zsh wiring, `starship prompt` renders clean + error, each feedback module fires under `--status=1` / `--cmd-duration=5000` / `--jobs=1` / `CLAUDECODE=1`, live prompt carries Powerline + macOS + arrow codepoints, and six config-file PUA invariants (git / c / python / clock / Downloads / Pictures) so the silent-strip failure class can't hide again

**Docs (`docs/starship.md` + `.zh.md`)**
- How it works · segment rationale · adding segments / custom modules · health check (automated + manual) · troubleshooting · gotchas
- `docs/zsh.md` + `.zh.md` drop the "until Phase 4" vi-mode caveats now that starship provides the indicator

## Checklist / 检查清单

- [x] Commit messages follow Conventional Commits
- [x] `pre-commit run --all-files` passes locally (conventional-commit + trailing-whitespace + gitleaks all green)
- [x] `chezmoi diff` reviewed; clean, no unexpected deletions
- [x] New CLI tool → `starship`, `font-maple-mono-nf-cn` added to `Brewfile`
- [x] Smoke-tested end-to-end on this Mac — repeated visual confirmation rounds; all four feedback modules + vi-mode indicator verified in a real TTY

## Notes for reviewer / 给 reviewer 的说明

**Why nine commits and not a tidy one.** The first commit looked "fine" by every automated check — until the prompt was actually rendered in a terminal. Rounds of visual feedback surfaced five separate silent strips of PUA codepoints (powerline triangles, character arrows, Dev-Icon symbols for git/c/python, the time clock icon, two directory-substitution icons). Each round added targeted fixes + tests to prevent the same regression from hiding again. Keeping the commits distinct rather than squashing-then-force-pushing preserves that learning for future re-authoring passes.

**Why `font-maple-mono-nf-cn` and not JetBrains Mono NF.** User preference. The cask install is idempotent via `brew install --cask --force` and is now part of `brew bundle`, so a fresh machine picks it up automatically. Terminal `font-family` still needs to be set manually until Phase 4b wires it into Ghostty.

**Known visual quirk.** In directories with no C or Python project, the green (git) → teal (c/python) → mauve (time) transition renders as two triangles glued together at the teal gap — because the teal segment has no content to fill it. This is the original config's behaviour and was accepted; happy to collapse if reviewer prefers.

**Out of scope.** Ghostty config (Phase 4b), Fastfetch (4c), Yazi (4d), bat cache rebuild (unrelated bat 0.26.1 version bump — `bat cache --clear` fixes it locally).

---
_Generated with Claude Code._
