### PR TITLE
fix(starship): trail feedback on terminal bg + vi-normal mauve

### DIFF
--- a/docs/starship.md
+++ b/docs/starship.md
@@ -2,7 +2,7 @@
 
 > English · [中文](starship.zh.md)
 
-Cross-shell prompt written in Rust. We use it for: two-line powerline context, Catppuccin Mocha palette matching `$BAT_THEME`, vi-mode visual cue (paired with OMZP::vi-mode), and three feedback modules that only show when they matter.
+Cross-shell prompt written in Rust. We use it for: single-line powerline context + trailing feedback on terminal bg, Catppuccin Mocha palette matching `$BAT_THEME`, vi-mode visual cue (paired with OMZP::vi-mode), and four feedback modules that only show when they matter.
 
 ## How it works
 
@@ -14,12 +14,12 @@ Cross-shell prompt written in Rust. We use it for: two-line powerline context, C
 
 ## Prompt layout
 
-Two lines:
+Line 1 holds the powerline ribbon; feedback trails it on terminal bg so semantic colors aren't eaten by `bg:mauve`. Line 2 is just `$character`.
 
-    ╭─  bytedance  ~/.dotfiles   feat/starship  ✓    19:42  ╮
-    ╰─   ✘ 1 took 14s ✦ 2 󰭹 claude
+    ╭─  ~/.dotfiles   main  ✓    19:42 ▶ ✘ ERROR took 14s ✦ 2 󰭹 claude
+    ╰─ ❯
 
-**Line 1 — context (powerline segments, always visible):**
+**Line 1, ribbon — context (always visible, coloured backgrounds):**
 
 | Segment | What | Rationale |
 |---|---|---|
@@ -28,17 +28,18 @@ Two lines:
 | `$directory` | 3-level truncated path | substitutions render common dirs as nerd-font icons. |
 | `$git_branch + $git_status` | branch + dirty markers | single segment, one color — branch always fits on one glance. |
 | `$c + $python` | C / Python version | algo research stack. `$package` removed (node/rust noise). |
-| `$time` | `%R` wall clock | no tmux status bar, so prompt is where the clock lives. |
+| `$time` | `%R` wall clock | no tmux status bar, so prompt is where the clock lives. Closes the ribbon. |
 
-**Line 2 — feedback (no background, visible only when triggered):**
+**Line 1, trailing — feedback (inline after the ribbon, no background, shown only when triggered):**
 
-| Module | Fires when | Why |
-|---|---|---|
-| `$status` | last command exited non-zero | fail-loud instead of fail-quiet. |
-| `$cmd_duration` | last command ran ≥ 3s | training / OJ runs — "did this actually take that long?" without `time`. |
-| `$jobs` | ≥ 1 background job | `&`-launched training jobs stay visible. |
-| `$custom.claude` | `CLAUDECODE=1` is set | prompt in a shell spawned inside a Claude Code session is visually distinct. |
-| `$character` | always last | red on failure, green on success, mauve on vi-normal. |
+| Module | Fires when | Color | Why |
+|---|---|---|---|
+| `$status` | last command exited non-zero | `bold fg:red` | fail-loud instead of fail-quiet. |
+| `$cmd_duration` | last command ran ≥ 3s | `fg:yellow` | training / OJ runs — "did this actually take that long?" without `time`. |
+| `$jobs` | ≥ 1 background job | `fg:sapphire` | `&`-launched training jobs stay visible. |
+| `$custom.claude` | `CLAUDECODE=1` is set | `bold fg:mauve` | prompt in a shell spawned inside a Claude Code session is visually distinct. |
+
+**Line 2 — `$character` only:** green `❯` on success, red `❯` on failure, mauve `❮` in vi-normal.
 
 ## Change a segment
 
@@ -67,19 +68,19 @@ Append `$custom` to the `format` block once — it expands to every `[custom.*]`
 bash tests/starship.sh
 ```
 
-20 checks: starship on PATH, config file present, `starship print-config` parses, tools.zsh wires it, `starship prompt` renders clean + error states, each feedback module fires under the right input (`--status=1`, `--cmd-duration=5000`, `--jobs=1`, `CLAUDECODE=1`), live prompt output carries Powerline + macOS + arrow codepoints, and the config file still has git / c / python / clock / Downloads / Pictures nerd-font glyphs — since PUA codepoints are invisible in most editors and got stripped five times during earlier rewrites.
+25 checks: starship on PATH, config file present, `starship print-config` parses, tools.zsh wires it, `starship prompt` renders clean + error states, each feedback module fires under the right input (`--status=1`, `--cmd-duration=5000`, `--jobs=1`, `CLAUDECODE=1`), live prompt output carries Powerline + macOS + arrow codepoints, config still has git / c / python / clock / Downloads / Pictures nerd-font glyphs (PUA codepoints are invisible in most editors and got stripped five times during earlier rewrites), feedback modules don't carry `bg:mauve` (regression guard — they used to sit inside the ribbon with salmon-on-purple contrast), and `vimcmd_symbol` uses `fg:mauve` (regression guard — was `fg:green` and visually identical to success).
 
 ### Manual (real TTY required)
 
 Open a new terminal tab:
 
-1. Prompt shows **two lines** — first line powerline segments, second line just `❯`.
+1. Prompt shows **two lines** — first line ribbon + (possibly) trailing feedback, second line just `❯`.
 2. Nerd-font glyphs render as icons (mac 󰀵, chat 󰭹, ✦), not `□` boxes. The Brewfile-pinned font is **Maple Mono NF CN**; if glyphs are boxes your terminal's `font-family` isn't pointing at it.
-3. `sleep 4` — line 2 should show yellow `took 4s`.
-4. `false` — line 2 should show red `✘ 1`.
-5. `sleep 100 &` — `$jobs` should show cyan `✦ 1`. `wait` or `kill %1` to clean up.
-6. Inside Claude Code, `$CLAUDECODE=1` — line 2 should show mauve `󰭹 claude`.
-7. Press Esc after typing something — `❯` should turn mauve (vi-normal mode).
+3. `sleep 4` — after the time segment, yellow `took 4s` appears (trails the ribbon, no bg).
+4. `false` — trailing feedback shows **bold red** `✘ ERROR`.
+5. `sleep 100 &` — trailing feedback shows **sapphire** `✦ 1`. `wait` or `kill %1` to clean up.
+6. Inside Claude Code, `$CLAUDECODE=1` — trailing feedback shows **bold mauve** `󰭹 claude`.
+7. Press Esc after typing something — the line-2 arrow flips from green `❯` to **mauve `❮`** (vi-normal).
 
 ## Troubleshooting
 

--- a/docs/starship.zh.md
+++ b/docs/starship.zh.md
@@ -2,7 +2,7 @@
 
 > [English](starship.md) · 中文
 
-Rust 写的跨 shell prompt。我们用它做：双行 powerline 上下文、Catppuccin Mocha 色板（与 `$BAT_THEME` 一致）、vi-mode 视觉反馈（配合 OMZP::vi-mode），以及三个"只在需要时出现"的反馈 module。
+Rust 写的跨 shell prompt。我们用它做：单行 powerline 上下文 + 尾随反馈（落在终端背景上）、Catppuccin Mocha 色板（与 `$BAT_THEME` 一致）、vi-mode 视觉反馈（配合 OMZP::vi-mode），以及四个"只在需要时出现"的反馈 module。
 
 ## How it works
 
@@ -14,12 +14,12 @@ Rust 写的跨 shell prompt。我们用它做：双行 powerline 上下文、Cat
 
 ## Prompt 布局
 
-两行：
+第 1 行是 powerline ribbon；反馈 module 接在 ribbon 后面的终端背景上，避免 semantic color 被 `bg:mauve` 吃掉。第 2 行只有 `$character`。
 
-    ╭─  bytedance  ~/.dotfiles   feat/starship  ✓    19:42  ╮
-    ╰─   ✘ 1 took 14s ✦ 2 󰭹 claude
+    ╭─  ~/.dotfiles   main  ✓    19:42 ▶ ✘ ERROR took 14s ✦ 2 󰭹 claude
+    ╰─ ❯
 
-**第 1 行 —— 上下文（powerline 段，始终可见）：**
+**第 1 行 · ribbon —— 上下文（始终可见，段段带背景色）：**
 
 | 段 | 内容 | 理由 |
 |---|---|---|
@@ -28,17 +28,18 @@ Rust 写的跨 shell prompt。我们用它做：双行 powerline 上下文、Cat
 | `$directory` | 3 级截断路径 | substitutions 把常用目录渲成 nerd-font 图标 |
 | `$git_branch + $git_status` | 分支 + dirty 标记 | 一段一色 —— 瞟一眼就知道分支状态 |
 | `$c + $python` | C / Python 版本 | 算法研究栈。`$package` 删掉了（node / rust 噪音） |
-| `$time` | `%R` 时钟 | 没有 tmux status bar，prompt 就是时钟位置 |
+| `$time` | `%R` 时钟 | 没有 tmux status bar，prompt 就是时钟位置。ribbon 的收口段 |
 
-**第 2 行 —— 反馈（无背景，只在触发时出现）：**
+**第 1 行 · 尾随 —— 反馈（跟在 ribbon 后面，无背景，触发才显示）：**
 
-| Module | 触发条件 | 理由 |
-|---|---|---|
-| `$status` | 上条命令 exit ≠ 0 | fail-loud，不要静默失败 |
-| `$cmd_duration` | 上条命令 ≥ 3s | 训练 / OJ run —— 不用 `time` 就知道"这条真的跑了这么久？" |
-| `$jobs` | 至少一个后台任务 | `&` 启的训练任务一直可见 |
-| `$custom.claude` | `CLAUDECODE=1` | 在 Claude Code session 内部开的 shell 视觉上可区分 |
-| `$character` | 永远最后 | 失败红、成功绿、vi-normal 紫 |
+| Module | 触发条件 | 颜色 | 理由 |
+|---|---|---|---|
+| `$status` | 上条命令 exit ≠ 0 | `bold fg:red` | fail-loud，不要静默失败 |
+| `$cmd_duration` | 上条命令 ≥ 3s | `fg:yellow` | 训练 / OJ run —— 不用 `time` 就知道"这条真的跑了这么久？" |
+| `$jobs` | 至少一个后台任务 | `fg:sapphire` | `&` 启的训练任务一直可见 |
+| `$custom.claude` | `CLAUDECODE=1` | `bold fg:mauve` | 在 Claude Code session 内部开的 shell 视觉上可区分 |
+
+**第 2 行 —— 只有 `$character`：** 成功绿 `❯`、失败红 `❯`、vi-normal 紫 `❮`。
 
 ## 改段
 
@@ -67,19 +68,19 @@ style       = "bold fg:lavender"
 bash tests/starship.sh
 ```
 
-20 条检查：starship 在 PATH、config 文件存在、`starship print-config` 解析、tools.zsh 接线成功、`starship prompt` 正常 + 异常都能渲染、每个反馈 module 在正确输入下 fire（`--status=1`、`--cmd-duration=5000`、`--jobs=1`、`CLAUDECODE=1`）、live prompt 输出携带 Powerline + macOS + arrow 码点，以及 config 文件里 git / c / python / 时钟 / Downloads / Pictures 的 nerd-font 字形依然在位 —— 这些 PUA 码点在大多数编辑器里隐形，早期重写时被静默吞掉过五次。
+25 条检查：starship 在 PATH、config 文件存在、`starship print-config` 解析、tools.zsh 接线成功、`starship prompt` 正常 + 异常都能渲染、每个反馈 module 在正确输入下 fire（`--status=1`、`--cmd-duration=5000`、`--jobs=1`、`CLAUDECODE=1`）、live prompt 输出携带 Powerline + macOS + arrow 码点；config 文件里 git / c / python / 时钟 / Downloads / Pictures 的 nerd-font 字形依然在位（这些 PUA 码点在大多数编辑器里隐形，早期重写时被静默吞掉过五次）；反馈 module 都不带 `bg:mauve`（回归保护 —— 曾经挤在 ribbon 里，salmon 色糊在紫底上）；`vimcmd_symbol` 用 `fg:mauve`（回归保护 —— 曾经写成 `fg:green`，与 success 撞色）。
 
 ### 手动（需要真实 TTY）
 
 开新 terminal tab：
 
-1. Prompt 是**两行** —— 第一行 powerline 段，第二行只有 `❯`。
+1. Prompt 是**两行** —— 第一行 ribbon + (触发时的)尾随反馈，第二行只有 `❯`。
 2. Nerd-font 字形渲成图标（mac 󰀵、chat 󰭹、✦ 等），不是 `□` 方框。Brewfile 锁的字体是 **Maple Mono NF CN**；若看到方框，说明终端 `font-family` 没指向它。
-3. `sleep 4` —— 第二行应显示黄色 `took 4s`。
-4. `false` —— 第二行应显示红色 `✘ 1`。
-5. `sleep 100 &` —— `$jobs` 应显示青色 `✦ 1`；用 `wait` 或 `kill %1` 清理。
-6. 在 Claude Code 里 `$CLAUDECODE=1` —— 第二行应显示紫色 `󰭹 claude`。
-7. 键入后按 Esc —— `❯` 应变紫色（vi-normal 模式）。
+3. `sleep 4` —— time 段后面出现黄色 `took 4s`（跟在 ribbon 之后，无背景）。
+4. `false` —— 尾随反馈显示 **加粗红色** `✘ ERROR`。
+5. `sleep 100 &` —— 尾随反馈显示 **sapphire 蓝** `✦ 1`；用 `wait` 或 `kill %1` 清理。
+6. 在 Claude Code 里 `$CLAUDECODE=1` —— 尾随反馈显示 **加粗紫色** `󰭹 claude`。
+7. 键入后按 Esc —— 第 2 行箭头从绿色 `❯` 翻成 **紫色 `❮`**（vi-normal 模式）。
 
 ## Troubleshooting
 

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -3,9 +3,13 @@
 # Catppuccin Mocha palette — matches $BAT_THEME for repo-wide color consistency.
 palette = 'catppuccin_mocha'
 
-# Prompt layout:
-#   line 1 — context segments (powerline): os · user · dir · git · lang · time
-#   line 2 — feedback (no bg, invisible when idle): status · cmd_duration · jobs · claude · character
+# Prompt layout (single line of content + character on line 2):
+#   line 1 — powerline ribbon (os · user · dir · git · lang · time) ▶ trailing
+#            feedback on terminal bg (status · cmd_duration · jobs · claude).
+#   line 2 — $character only.
+# Feedback modules sit AFTER the ribbon's closing triangle so their semantic
+# colors (red / yellow / sapphire / mauve) show on plain terminal bg instead
+# of being eaten by bg:mauve.
 format = """
 [](surface0)\
 $os\
@@ -20,11 +24,11 @@ $c\
 $python\
 [](fg:teal bg:mauve)\
 $time\
+[](fg:mauve)\
 $status\
 $cmd_duration\
 $jobs\
 $custom\
-[ ](fg:mauve)\
 $line_break\
 $character"""
 
@@ -118,23 +122,25 @@ disabled = false
 # ─── Feedback modules (shown only when triggered) ────────────────────
 
 [status]
+# Rendered on the terminal background so `fg:red` actually reads as red —
+# a coloured ribbon underneath eats the warm salmon tone.
 disabled = false
 symbol = "✘ "
-format = '[$symbol$common_meaning$signal_name$maybe_int ]($style)'
-style = "bold fg:red bg:mauve"
+format = '[ $symbol$common_meaning$signal_name$maybe_int]($style)'
+style = "bold fg:red"
 map_symbol = true
 
 [cmd_duration]
 # Only show when the previous command ran ≥ 3s — signal, not noise.
 min_time = 3_000
-format = '[took $duration ]($style)'
-style = "fg:mantle bg:mauve"
+format = '[ took $duration]($style)'
+style = "fg:yellow"
 
 [jobs]
 symbol = "✦ "
 number_threshold = 1
-format = '[$symbol$number ]($style)'
-style = "fg:sapphire bg:mauve"
+format = '[ $symbol$number]($style)'
+style = "fg:sapphire"
 
 [custom.claude]
 # Active when $CLAUDECODE=1 is injected by a Claude Code session, so the
@@ -142,13 +148,13 @@ style = "fg:sapphire bg:mauve"
 description = "Claude Code session indicator"
 when = 'test -n "$CLAUDECODE"'
 command = "echo"
-format = '[󰭹 claude ]($style)'
-style = "bold fg:lavender bg:mauve"
+format = '[ 󰭹 claude]($style)'
+style = "bold fg:mauve"
 
 [character]
 success_symbol = '[](bold fg:green)'
 error_symbol = '[](bold fg:red)'
-vimcmd_symbol = '[](bold fg:green)'
+vimcmd_symbol = '[](bold fg:mauve)'
 vimcmd_replace_one_symbol = '[](bold fg:mauve)'
 vimcmd_replace_symbol = '[](bold fg:mauve)'
 vimcmd_visual_symbol = '[](bold fg:lavender)'

--- a/tests/starship.sh
+++ b/tests/starship.sh
@@ -80,6 +80,18 @@ check 'Downloads dir icon U+F019 in config'      'has_cp F019 "$STARSHIP_CFG"'
 check 'Pictures dir icon U+F03E in config'       'has_cp F03E "$STARSHIP_CFG"'
 
 echo
+echo "── Contrast / vi-mode invariants ────────────────────"
+# Regression guards for the fix/starship PR: feedback modules used to live
+# inside the mauve ribbon and had bg:mauve in their style, which killed
+# the semantic-color contrast. vi-normal was written as fg:green, making
+# it visually indistinguishable from the success arrow.
+check '[status] has no bg:mauve'                 '! grep -A2 "^\[status\]" "$STARSHIP_CFG" | grep -q "bg:mauve"'
+check '[cmd_duration] has no bg:mauve'           '! grep -A3 "^\[cmd_duration\]" "$STARSHIP_CFG" | grep -q "bg:mauve"'
+check '[jobs] has no bg:mauve'                   '! grep -A4 "^\[jobs\]" "$STARSHIP_CFG" | grep -q "bg:mauve"'
+check '[custom.claude] has no bg:mauve'          '! grep -A6 "^\[custom.claude\]" "$STARSHIP_CFG" | grep -q "bg:mauve"'
+check 'vimcmd_symbol uses fg:mauve'              'grep -q "^vimcmd_symbol.*fg:mauve" "$STARSHIP_CFG"'
+
+echo
 echo "─────────────────────────────────────────────────────"
 if (( FAIL > 0 )); then
     printf "  \033[31m%d passed, %d failed\033[0m\n" $PASS $FAIL

--- a/tests/starship.sh
+++ b/tests/starship.sh
@@ -111,7 +111,7 @@ check '[status] has no bg:mauve'                 '! section_has status "$STARSHI
 check '[cmd_duration] has no bg:mauve'           '! section_has cmd_duration "$STARSHIP_CFG" "bg:mauve"'
 check '[jobs] has no bg:mauve'                   '! section_has jobs "$STARSHIP_CFG" "bg:mauve"'
 check '[custom.claude] has no bg:mauve'          '! section_has custom.claude "$STARSHIP_CFG" "bg:mauve"'
-check 'vimcmd_symbol uses fg:mauve'              'grep -q "^vimcmd_symbol.*fg:mauve" "$STARSHIP_CFG"'
+check 'vimcmd_symbol uses fg:mauve'              'sed "s/#.*//" "$STARSHIP_CFG" | grep -q "^vimcmd_symbol.*fg:mauve"'
 
 echo
 echo "─────────────────────────────────────────────────────"

--- a/tests/starship.sh
+++ b/tests/starship.sh
@@ -70,7 +70,18 @@ check 'macOS nerd-font icon (U+F0035) present'   '(( MAC >= 1 ))'
 check 'character arrow glyph (U+F432) present'   '(( ARROW >= 1 ))'
 STARSHIP_CFG="$HOME/.config/starship.toml"
 has_cp() { python3 -c 'import sys; sys.exit(0 if chr(int(sys.argv[1],16)) in open(sys.argv[2]).read() else 1)' "$1" "$2"; }
-export -f has_cp
+# Check whether a TOML section ([name]) contains a substring. Reads from the
+# section header up to the next top-level header (or EOF). Prefer this over
+# `grep -AN` — section length changes silently break magic N.
+section_has() {
+    python3 -c '
+import re, sys
+text = open(sys.argv[2]).read()
+m = re.search(r"^\[" + re.escape(sys.argv[1]) + r"\]\n(.*?)(?=^\[|\Z)", text, re.DOTALL | re.MULTILINE)
+sys.exit(0 if m and sys.argv[3] in m.group(1) else 1)
+' "$1" "$2" "$3"
+}
+export -f has_cp section_has
 export STARSHIP_CFG
 check '[git_branch] symbol U+F418 in config'     'has_cp F418 "$STARSHIP_CFG"'
 check '[c] symbol U+E61E in config'              'has_cp E61E "$STARSHIP_CFG"'
@@ -85,10 +96,10 @@ echo "── Contrast / vi-mode invariants ────────────�
 # inside the mauve ribbon and had bg:mauve in their style, which killed
 # the semantic-color contrast. vi-normal was written as fg:green, making
 # it visually indistinguishable from the success arrow.
-check '[status] has no bg:mauve'                 '! grep -A2 "^\[status\]" "$STARSHIP_CFG" | grep -q "bg:mauve"'
-check '[cmd_duration] has no bg:mauve'           '! grep -A3 "^\[cmd_duration\]" "$STARSHIP_CFG" | grep -q "bg:mauve"'
-check '[jobs] has no bg:mauve'                   '! grep -A4 "^\[jobs\]" "$STARSHIP_CFG" | grep -q "bg:mauve"'
-check '[custom.claude] has no bg:mauve'          '! grep -A6 "^\[custom.claude\]" "$STARSHIP_CFG" | grep -q "bg:mauve"'
+check '[status] has no bg:mauve'                 '! section_has status "$STARSHIP_CFG" "bg:mauve"'
+check '[cmd_duration] has no bg:mauve'           '! section_has cmd_duration "$STARSHIP_CFG" "bg:mauve"'
+check '[jobs] has no bg:mauve'                   '! section_has jobs "$STARSHIP_CFG" "bg:mauve"'
+check '[custom.claude] has no bg:mauve'          '! section_has custom.claude "$STARSHIP_CFG" "bg:mauve"'
 check 'vimcmd_symbol uses fg:mauve'              'grep -q "^vimcmd_symbol.*fg:mauve" "$STARSHIP_CFG"'
 
 echo

--- a/tests/starship.sh
+++ b/tests/starship.sh
@@ -70,15 +70,26 @@ check 'macOS nerd-font icon (U+F0035) present'   '(( MAC >= 1 ))'
 check 'character arrow glyph (U+F432) present'   '(( ARROW >= 1 ))'
 STARSHIP_CFG="$HOME/.config/starship.toml"
 has_cp() { python3 -c 'import sys; sys.exit(0 if chr(int(sys.argv[1],16)) in open(sys.argv[2]).read() else 1)' "$1" "$2"; }
-# Check whether a TOML section ([name]) contains a substring. Reads from the
-# section header up to the next top-level header (or EOF). Prefer this over
-# `grep -AN` — section length changes silently break magic N.
+# Check whether a TOML section ([name]) *code* contains a substring. Reads
+# from the section header up to the next top-level header (or EOF), then
+# strips `# ...` comments so a substring match on a discussion of a value
+# doesn't false-positive. The comment-strip is load-bearing: during fix/
+# starship bring-up the helper tripped on a comment that mentioned
+# `bg:mauve` rather than used it. Tolerates trailing whitespace / inline
+# comment on the header line and indented next-section headers (TOML allows
+# both, even if we don't use them).
 section_has() {
     python3 -c '
 import re, sys
 text = open(sys.argv[2]).read()
-m = re.search(r"^\[" + re.escape(sys.argv[1]) + r"\]\n(.*?)(?=^\[|\Z)", text, re.DOTALL | re.MULTILINE)
-sys.exit(0 if m and sys.argv[3] in m.group(1) else 1)
+m = re.search(
+    r"^\[" + re.escape(sys.argv[1]) + r"\][^\n]*\n(.*?)(?=^\s*\[|\Z)",
+    text, re.DOTALL | re.MULTILINE,
+)
+if not m:
+    sys.exit(1)
+body = re.sub(r"#[^\n]*", "", m.group(1))
+sys.exit(0 if sys.argv[3] in body else 1)
 ' "$1" "$2" "$3"
 }
 export -f has_cp section_has


### PR DESCRIPTION
<!--
Title should follow Conventional Commits: `<type>(<scope>?): <subject>`
标题遵循 Conventional Commits：`<type>(<scope>?): <subject>`
-->

## Summary / 概述

Three visual bugs surfaced after #8 merged, caught in real-TTY screenshots:

- Feedback modules (`$status` / `$cmd_duration` / `$jobs` / `$custom.claude`) sat inside the mauve time ribbon with `bg:mauve`, which ate every semantic foreground — red washed into salmon, sapphire into pastel blue, lavender claude into bare purple.
- `vimcmd_symbol` was `fg:green`, visually identical to the success arrow — Esc flipped the glyph direction but left the color unchanged, contradicting the documented "mauve on vi-normal" contract.
- In-config layout comment and `docs/starship{,.zh}.md` both claimed "line 2 — feedback", but the actual format block has feedback trailing on line 1 after the ribbon (the intentional choice from #8).

三个实际 TTY 里才暴露的视觉 bug —— ribbon 吃色、vi-normal 撞色、文档与配置漂移。

## Change type / 变更类型

- [x] `fix` — bug fix · bug 修复

## Checklist / 检查清单

- [x] Commit messages follow Conventional Commits
- [x] `pre-commit run --all-files` passes locally
- [x] `chezmoi diff` reviewed; no surprising deletions or permission changes

## Notes for reviewer / 给 reviewer 的说明

**Design change** — feedback modules leave the mauve ribbon.

Before: `... $time $status $cmd_duration $jobs $custom [closing-triangle]` — all on `bg:mauve`, semantic colors eaten.
After: `... $time [closing-triangle] $status $cmd_duration $jobs $custom` — feedback trails on terminal bg with `fg:red` / `fg:yellow` / `fg:sapphire` / `fg:mauve`, no background. Still line 1, still "接在时间后面" — just not inside the ribbon.

**Regression guards (+5 checks, total 25)** in `tests/starship.sh`:
- `[status]` / `[cmd_duration]` / `[jobs]` / `[custom.claude]` must not reference `bg:mauve`.
- `vimcmd_symbol` must use `fg:mauve`.

These guard against the exact drifts this PR fixes — future edits that put feedback back in the ribbon or flip vi-normal green will now fail CI.

**Out of scope** — the real-TTY manual checklist in `docs/starship.md` covers visual verification (colors, glyphs, vi-mode); automated tests can only assert config-level invariants. Bumped check count from 20 → 25 in both language docs.
