### PR TITLE
feat(yazi): TUI file manager with image preview + Mocha + plugin trio

### DIFF
--- a/.chezmoiscripts/run_onchange_after_40-yazi-plugins.sh
+++ b/.chezmoiscripts/run_onchange_after_40-yazi-plugins.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Install yazi plugins via `ya pkg add`.
+#
+# run_onchange: the script body is content-hashed by chezmoi — adding or
+# removing a plugin below changes the hash and triggers a re-run on the
+# next `chezmoi apply`. `ya pkg` is idempotent: listing an already-added
+# plugin in package.toml costs nothing; re-runs after the list stabilizes
+# are skipped entirely by `ya pkg install`.
+#
+# Runs AFTER the Brewfile script (id 20) so `yazi`/`ya` are on PATH.
+#
+# Subcommand notes (yazi ≥26.x):
+#   ya pkg add <repo:plugin>   — append to package.toml + install
+#   ya pkg install             — install every plugin listed in package.toml
+#   ya pkg list                — dump current package set for inspection
+# Older yazi (≤0.4) shipped `ya pack -a` instead; fix here if you're
+# pinning to an older brew.
+set -euo pipefail
+
+if ! command -v ya >/dev/null 2>&1; then
+    echo "==> ya not on PATH — skipping yazi plugin install."
+    echo "    (Brewfile installs it via 'brew install yazi'; run 'brew bundle' first.)"
+    exit 0
+fi
+
+plugins=(
+    "yazi-rs/plugins:git"
+    "yazi-rs/plugins:smart-enter"
+    "yazi-rs/plugins:full-border"
+    # Flavors go through the same `ya pkg add` channel as plugins.
+    # Landing dir differs (plugins/ vs flavors/) but the install
+    # syntax is identical — yazi auto-routes by repo path.
+    "yazi-rs/flavors:catppuccin-mocha"
+)
+
+# Detect the plugin set yazi already knows about to keep `ya pkg add`
+# quiet when nothing changed. `ya pkg list` prints one line per plugin,
+# repo:plugin formatted — grep-friendly.
+existing=$(ya pkg list 2>/dev/null || true)
+
+for p in "${plugins[@]}"; do
+    if grep -qF "$p" <<<"$existing"; then
+        echo "==> $p already registered — skipping"
+        continue
+    fi
+    echo "==> ya pkg add $p"
+    ya pkg add "$p"
+done
+
+# One final `install` reconciles state — if package.toml exists but the
+# package/ dir was wiped, this re-fetches sources without re-adding.
+echo "==> ya pkg install"
+ya pkg install

--- a/Brewfile
+++ b/Brewfile
@@ -29,6 +29,18 @@ brew "git-delta"  # binary is `delta`
 # ---- Editor ----------------------------------------------------------------
 brew "neovim"
 
+# ---- File manager (yazi) ---------------------------------------------------
+# yazi auto-detects these on PATH for previewers; no yazi.toml wiring needed.
+#   ffmpegthumbnailer → video first-frame thumbs
+#   imagemagick       → HEIC/RAW and other non-native image formats
+#   poppler           → PDF page preview via `pdftoppm`
+#   sevenzip          → archive listing (zip/7z/rar)
+brew "yazi"
+brew "ffmpegthumbnailer"
+brew "imagemagick"
+brew "poppler"
+brew "sevenzip"
+
 # ---- Python ----------------------------------------------------------------
 brew "uv"
 

--- a/docs/yazi.md
+++ b/docs/yazi.md
@@ -1,0 +1,307 @@
+# Yazi
+
+> English · [中文](yazi.zh.md)
+
+Blazing-fast Rust TUI file manager. Three-column pane (parent / current / preview), vim-ish keys, native image/video/PDF preview, built-in integrations with `fzf` / `zoxide` / `fd` / `rg`. Bound to `y` (a shell function, not an alias — see below) so quitting yazi drops you into whichever directory you last browsed.
+
+## How it works
+
+| Thing | Where | Note |
+|---|---|---|
+| Config | `~/.config/yazi/yazi.toml` ← source `dot_config/yazi/yazi.toml` | Manager / preview / opener. Reloaded on every launch — no daemon. |
+| Keymap | `~/.config/yazi/keymap.toml` ← source `dot_config/yazi/keymap.toml` | `prepend_keymap` stacks on top of yazi's defaults. |
+| Theme | `~/.config/yazi/theme.toml` ← source `dot_config/yazi/theme.toml` | Activates the `catppuccin-mocha` flavor (UI palette + syntect tmTheme for syntax-highlighted previews). |
+| Init | `~/.config/yazi/init.lua` ← source `dot_config/yazi/init.lua` | Plugin bootstrap (`full-border`, `git`). |
+| Plugin dir | `~/.config/yazi/plugins/` | Populated by `ya pkg add` via `.chezmoiscripts/run_onchange_after_40-yazi-plugins.sh`. **Not in source** — regenerated on apply. |
+| Flavor dir | `~/.config/yazi/flavors/` | Same mechanism as plugin dir; stores full theme packs (`catppuccin-mocha`). **Not in source.** |
+| Shell wrapper | `~/.config/zsh/tools.zsh` → `y()` function | Runs `yazi --cwd-file=$tmp`; on quit, parent shell `cd`s to yazi's last CWD. |
+| Cache | `~/.cache/yazi/` | Image/video thumbnails. Safe to delete — regenerated on next preview. |
+
+## Concepts
+
+Before tweaking anything, useful to know:
+
+**Two binaries, one brew:** `brew install yazi` ships both `yazi` (the TUI) and `ya` (its control channel — used by `ya pkg` for plugins, `ya emit` for scripted events). You'll rarely call `ya` by hand; it mostly lives behind the plugin manager.
+
+**Three columns, one ratio:** `[mgr] ratio = [1, 3, 4]` — parent / current / preview. Preview is widest because that's where image/video/code-with-syntax-highlight lives. Shrink/expand preview with `h` / `l` (bound when cursor is over preview).
+
+**Opener rules, not hardcoded:** "What happens when I press `<Enter>` on a file?" isn't wired to a single command. It walks `[open] prepend_rules` top-to-bottom: first rule whose `mime` / `name` matches wins, and its `use = [...]` list picks an opener block from `[opener]`. This is why we can send `.sh` files to `nvim` without touching the macOS Launch Services handler for everything else.
+
+**Plugins vs flavors:** A **plugin** extends behavior (new previewer, keybind, status column). A **flavor** is a theme pack with UI palette + tmTheme for syntax-highlighted previews. Both are installed through `ya pkg add`. We ship three plugins (`git`, `smart-enter`, `full-border`) and one flavor (`catppuccin-mocha`) — the flavor keeps yazi's preview syntax colors aligned with bat / starship / fastfetch, so the whole terminal stack reads as one palette.
+
+**Terminal image protocol:** Yazi picks the image rendering protocol by sniffing `$TERM` / `$TERM_PROGRAM`. Ghostty implements the **Kitty graphics protocol** natively → pixel-perfect inline images with zero extra deps. Other terms (iTerm2 → iTerm2 protocol, tmux-without-passthrough → chafa fallback, Apple Terminal → none) degrade silently.
+
+## Quick start (5-min tour)
+
+1. Launch: type `y` in any shell.
+2. Navigate: `j`/`k` move, `h` out, `l` in (into dir, or open file — `smart-enter` plugin).
+3. See a directory tree scroll past: press `.` to toggle hidden files.
+4. Mark multiple files: `space` toggles selection; `v` visual-select a range.
+5. Copy + paste: navigate to source, `y`, navigate to target, `p`.
+6. Rename one: `r`, edit, Enter.
+7. **Bulk rename**: multi-select with `space` → `r` → yazi opens `$EDITOR` with all selected names → edit lines → save → yazi applies diff.
+8. Search: `/` filename-grep current dir, `s` fd-find anywhere, `S` rg full-text search.
+9. Jump: `z` zoxide (frecency), `Z` fzf (fuzzy over all dirs).
+10. Find + enter a file via fzf: `Z`, type fragment, Enter, `l` to open.
+11. Quit: `q` → shell `cd`s to yazi's last directory. `Q` quits without `cd`.
+
+If step 1 fails with `command not found`, run `chezmoi apply` — Brewfile + plugin install happen there.
+
+## Keymap reference
+
+Our `keymap.toml` only overrides `l` / `<Enter>` for `smart-enter`. Everything else is yazi default. Press `~` in yazi for the live help overlay.
+
+### Navigation
+
+| Keys | Action |
+|---|---|
+| `h` / `j` / `k` / `l` | left / down / up / right (l = smart-enter) |
+| `gg` / `G` | top / bottom |
+| `Ctrl+u` / `Ctrl+d` | half-page up / down |
+| `H` / `L` | history back / forward |
+| `Tab` | switch to next tab |
+| `t` | new tab at cursor location |
+| `1`..`9` | jump to tab N |
+| `[` / `]` | previous / next tab |
+
+### Selection
+
+| Keys | Action |
+|---|---|
+| `space` | toggle selection at cursor |
+| `v` | enter visual-select mode |
+| `Ctrl+a` | select all in current dir |
+| `Ctrl+r` | reverse selection |
+| `Esc` | clear selection |
+
+### File operations
+
+| Keys | Action |
+|---|---|
+| `y` | yank (copy) selection |
+| `x` | cut selection |
+| `p` | paste into current dir |
+| `P` | paste with overwrite |
+| `d` | move to Trash |
+| `D` | permanent delete (no trash) |
+| `a` | create file; trailing `/` creates a dir |
+| `r` | rename (multi-select → bulk rename via `$EDITOR`) |
+| `c` | copy full path to clipboard (submenu) |
+
+### Search / jump
+
+| Keys | Action |
+|---|---|
+| `/` | filter current dir (filename substring) |
+| `?` | reverse filter |
+| `n` / `N` | next / previous match |
+| `s` | search files by name (via `fd`) |
+| `S` | search file contents (via `rg`) |
+| `z` | zoxide jump (needs zoxide) |
+| `Z` | fzf jump (needs fzf) |
+| `f` / `F` | find next / prev in current dir |
+
+### Preview / layout
+
+| Keys | Action |
+|---|---|
+| `K` / `J` | scroll preview up / down |
+| `T` | toggle preview pane |
+| `,` | sort submenu (a/c/m/s/e, `r` reverse) |
+| `M` | linemode submenu (size / ctime / mtime / perms / owner / none) |
+| `.` | toggle hidden files |
+
+### Tasks / shell
+
+| Keys | Action |
+|---|---|
+| `w` | task manager (background copies, extracts) |
+| `:` | command palette (run yazi commands) |
+| `!` | run shell command, block yazi |
+| `Shift+!` | open shell in current directory |
+| `Esc` | close menu / exit mode |
+| `q` | quit; shell `cd`s to last yazi directory |
+| `Q` | quit without `cd` |
+
+### Spot (file metadata panel)
+
+| Keys | Action |
+|---|---|
+| (move to file) + `Tab` | cycle metadata panels (file / EXIF / linked targets) |
+
+## Shell wrapper `y()`
+
+Canonical yazi-as-cd pattern. Without this wrapper, `yazi` just runs, shows stuff, quits, and you're still in whatever directory you started. With it:
+
+```zsh
+y() {
+    local tmp cwd
+    tmp="$(mktemp -t 'yazi-cwd.XXXXXX')"
+    yazi "$@" --cwd-file="$tmp"           # yazi writes its last CWD here on quit
+    if cwd="$(command cat -- "$tmp")" && [[ -n $cwd && $cwd != "$PWD" ]]; then
+        builtin cd -- "$cwd"              # parent shell follows
+    fi
+    rm -f -- "$tmp"
+}
+```
+
+Why `command cat` and `builtin cd`: our `aliases.zsh` rebinds `cat` → `bat` (colorized) and zsh can shadow `cd` with functions. Bypassing both keeps the wrapper robust if someone monkey-patches either later.
+
+## Plugins + flavor
+
+Listed in `.chezmoiscripts/run_onchange_after_40-yazi-plugins.sh`. Adding or removing a line there content-hashes the script → chezmoi re-runs on next `apply` → `ya pkg add` is invoked. `ya pkg add` is idempotent: already-registered packages exit silently, so re-runs cost ~0.
+
+| Package | Kind | What it does | Wired by |
+|---|---|---|---|
+| `yazi-rs/plugins:git` | plugin | Decorates files with git status glyphs (`M` modified, `A` added, `?` untracked, `!` ignored) in the left gutter. | `yazi.toml [plugin.prepend_fetchers]` registers the fetcher; `init.lua` calls `require("git"):setup({ order = 1500 })`. |
+| `yazi-rs/plugins:smart-enter` | plugin | Unifies `l` + `<Enter>`: directory → cd in; file → opener fires. No more "did I need `l` or `<Enter>` here?". | `keymap.toml [mgr] prepend_keymap` binds both keys to `plugin smart-enter`. |
+| `yazi-rs/plugins:full-border` | plugin | Rounded borders around all three columns. Pure visual polish. | `init.lua` calls `require("full-border"):setup()`. Remove that one line to disable. |
+| `yazi-rs/flavors:catppuccin-mocha` | flavor | Full UI palette + tmTheme for syntect previews — aligns with bat (`$BAT_THEME`), starship, and fastfetch so the whole terminal reads as one scheme. | `theme.toml [flavor] dark = "catppuccin-mocha"`. |
+
+### git fetcher syntax gotcha
+
+The git plugin's fetcher key is `url`, **not** `name`. Yazi silently accepts `name` but the fetcher never fires, so git glyphs quietly disappear. If you see no `M`/`A`/`?` in the gutter, check `yazi.toml`:
+
+```toml
+# Correct — yazi ≥26
+[[plugin.prepend_fetchers]]
+id    = "git"       # Optional on yazi > 26.1.22 per plugin README
+url   = "*"         # ← `url`, not `name`
+run   = "git"
+group = "git"
+```
+
+The `tests/yazi.sh` regression guard `fetcher uses url= (not name=)` exists because this already bit us once during bring-up.
+
+## Preview backends
+
+Yazi sniffs `$PATH` for these at render time. All installed via Brewfile — dropping one silently degrades that file type to text (or nothing, for binary).
+
+| File type | Backend | Brewfile entry |
+|---|---|---|
+| Image (PNG/JPG/GIF/WebP) | Kitty graphics protocol (built-in) | — |
+| Image (HEIC/RAW/exotic) | `magick` converts → Kitty | `imagemagick` |
+| Video (MP4/MOV/MKV) | `ffmpegthumbnailer` first-frame → Kitty | `ffmpegthumbnailer` |
+| PDF | `pdftoppm` first page → Kitty | `poppler` |
+| Archive (zip/7z/tar/rar) | `7z l` table-of-contents listing | `sevenzip` |
+| Code / text | Yazi's bundled syntect — themed by the active flavor's tmTheme → matches bat | — |
+| JSON | `jq` pretty-print (yazi built-in) | — |
+| Symlink | Target path + resolved target preview | — |
+
+## Change a setting
+
+1. Edit `dot_config/yazi/yazi.toml` (or `keymap.toml` / `init.lua`).
+2. No reload — yazi re-reads all three on every launch. Quit + `y` again.
+3. For structural changes (new section, changed fetcher id), run `tests/yazi.sh` to catch silent breakage.
+
+## Add a plugin
+
+1. Append a line to `.chezmoiscripts/run_onchange_after_40-yazi-plugins.sh`:
+
+    ```bash
+    plugins=(
+        "yazi-rs/plugins:git"
+        "yazi-rs/plugins:smart-enter"
+        "yazi-rs/plugins:full-border"
+        "your-user/your-plugin:name"    # ← new line
+    )
+    ```
+
+2. If the plugin is a **previewer / fetcher / preloader**, also wire it in `yazi.toml`:
+
+    ```toml
+    [plugin]
+    prepend_previewers = [
+      { mime = "image/*", run = "your-plugin" },
+    ]
+    ```
+
+3. If it exposes a **key-bindable command**, add to `keymap.toml`:
+
+    ```toml
+    [[mgr.prepend_keymap]]
+    on  = "X"
+    run = "plugin your-plugin"
+    ```
+
+4. If it needs **boot-time setup**, add `require("your-plugin"):setup()` in `init.lua`.
+5. `chezmoi apply` — the `run_onchange` hook fires, `ya pkg add` installs it.
+
+## Health check
+
+### Automated
+
+```bash
+bash tests/yazi.sh
+```
+
+~24 checks: binaries on PATH (`yazi`, `ya`), config + keymap + init.lua present, TOML parses (when python3 ≥ 3.11), expected sections / keys present, preview backends available (`ffmpegthumbnailer`, `magick`, `pdftoppm`, `7z`), plugins unpacked under `~/.config/yazi/plugins/` (skipped with a hint if apply hasn't run), Ghostty detection note.
+
+### Manual (real TTY required)
+
+1. In a fresh Ghostty tab: `y`.
+2. Three-column layout visible with **rounded borders** (`full-border` plugin).
+3. Arrow through a git repo — modified files carry a colored `M` / `A` / `?` glyph in the left gutter (`git` plugin).
+4. `l` on a directory → enters it; `l` on a text file → opens in nvim (`smart-enter` plugin). Quit nvim → back in yazi.
+5. Arrow to a PNG / JPG → preview shows the **actual image**, not ASCII art or `□` (Kitty graphics working).
+6. Arrow to an MP4 → preview shows first-frame thumbnail (ffmpegthumbnailer → Kitty).
+7. Arrow to a PDF → preview shows the rendered first page (poppler → Kitty).
+8. Press `s`, type a fragment → fd matches stream live.
+9. Press `Z`, type a fragment → fzf full-dir fuzzy picker. Enter → yazi jumps there.
+10. Quit with `q` — terminal shell `cd`s to wherever yazi last was (`y()` wrapper working).
+
+## Troubleshooting
+
+**`y: command not found`** — you haven't sourced `tools.zsh` yet in the current shell. Open a new terminal tab, or `source ~/.zshrc`. Check `type y` returns a function definition.
+
+**Image preview renders as blank / `□` / question marks** — Ghostty's Kitty protocol not reaching yazi. Check `echo $TERM_PROGRAM` prints `ghostty`. If running inside tmux/screen without passthrough, images won't render (known limitation — yazi falls back to no-op). Outside of Ghostty, you'd need chafa or a sixel terminal; we don't install those.
+
+**PDF preview shows text dump** — `pdftoppm` missing. `command -v pdftoppm` must work. Re-run `brew bundle` or `brew install poppler`.
+
+**Video preview shows nothing** — `ffmpegthumbnailer` missing. `brew install ffmpegthumbnailer`. Note: DRM'd video will fail anyway (no thumb extractable).
+
+**Git status glyphs missing** — two root causes:
+  1. Plugin not installed. Check `ls ~/.config/yazi/plugins/git.yazi` exists. If missing, `chezmoi apply`.
+  2. Fetcher key name wrong. `yazi.toml [[plugin.prepend_fetchers]]` uses `url = "*"` **not** `name = "*"` — yazi ≥26 silently drops `name`-keyed fetchers. `tests/yazi.sh` catches this; run it if glyphs vanish after an edit.
+
+**Preview syntax colors look off (not like bat)** — flavor not activated. Check `theme.toml` has `[flavor] dark = "catppuccin-mocha"` and `ls ~/.config/yazi/flavors/catppuccin-mocha.yazi` exists. Without the flavor, yazi's bundled syntect uses a generic dark theme that clashes with bat's Mocha palette.
+
+**`smart-enter` not bound** — plugin not installed. Check `~/.config/yazi/plugins/smart-enter.yazi` exists. If missing, `chezmoi apply` to trigger `ya pkg add`.
+
+**Borders missing (no rounding)** — `full-border` plugin not installed, or `init.lua` missing the `setup()` call. Confirm `~/.config/yazi/plugins/full-border.yazi` exists + `init.lua` has `require("full-border"):setup()`.
+
+**`ya pkg add` fails on first apply** — `ya` is part of the `yazi` brew. If brew install hasn't completed yet, the plugin hook exits with a hint and skips. Fix: `brew bundle` → re-apply. Note: on yazi ≤0.4 the subcommand was `ya pack -a`; the install script targets ≥26.x.
+
+**Opening `.sh` or `.py` launches `Terminal.app` instead of nvim** — `[open] prepend_rules` got skipped. Confirm `application/x-shellscript` rule is above the catch-all `{ name = "*" }` rule. Our yazi.toml has this correct; watch for it during edits.
+
+**Bulk rename opens a weird editor** — yazi honors `$EDITOR`. Check `echo $EDITOR` returns `nvim`. If empty, the bulk-rename UI won't launch.
+
+**`y` wrapper quits yazi but doesn't `cd`** — the wrapper only `cd`s when `$cwd` differs from `$PWD`. If you quit yazi at the same directory you started, no cd happens. Intentional.
+
+## Gotchas
+
+**Plugin install happens inside chezmoi, not `brew`.** Running `brew bundle` alone won't populate `~/.config/yazi/plugins/`. A full `chezmoi apply` is required — the `run_onchange_after_40-yazi-plugins.sh` hook is what invokes `ya pkg`.
+
+**`run_onchange` hashes the script body, not the plugin list.** If you edit the plugin array, the script body changes and re-runs. But if you manually `ya pkg delete <plugin>` to uninstall without touching the script, chezmoi won't notice and won't re-install on next apply. Re-edit the script (even touching a comment) to force re-run.
+
+**`$EDITOR` must be set for bulk rename.** Yazi's bulk-rename flow shells out to `$EDITOR`. Our `env.zsh` sets `EDITOR=nvim` — if that gets lost (remote session without env propagation), bulk rename silently falls back to a bad default.
+
+**Image preview blows up memory on giant files.** `[tasks] image_alloc = 512 MiB` is the hard cap. 100MP images exceed this; yazi gives up rather than OOM. Tuning the cap trades safety for coverage.
+
+**Ghostty image protocol skips frames on fast scrolling.** `[preview] image_delay = 30` ms debounces decoder calls. Lower it for snappier scrolling; raise it if you see tearing on a slow machine.
+
+**TOML parse errors are mostly silent.** Yazi boots with bad config and just ignores broken sections. Tests/yazi.sh does a python-based TOML parse check (needs python3 ≥ 3.11 for `tomllib`). On older python it only structural-greps — keep that in mind.
+
+**`plugins/` is not in chezmoi source.** Plugins live at destination only. If you clone this repo onto a fresh Mac and run `chezmoi apply`, the `run_onchange` script populates it. Don't try to `chezmoi add ~/.config/yazi/plugins` — it'd vendor megabytes of plugin source into the repo.
+
+## Rebuild from scratch
+
+```bash
+# Delete plugin cache + thumbnail cache — yazi rebuilds both on next launch.
+rm -rf ~/.config/yazi/plugins ~/.config/yazi/package.toml ~/.cache/yazi ~/.local/state/yazi
+
+# Re-run the install hook explicitly (or just `chezmoi apply`):
+chezmoi apply
+```
+
+If `y` runs but gives no preview, check: (1) `yazi` on PATH (`brew install yazi`), (2) `$TERM_PROGRAM=ghostty`, (3) preview backends (`ffmpegthumbnailer`, `magick`, `pdftoppm`, `7z`) on PATH, (4) plugins under `~/.config/yazi/plugins/`.

--- a/docs/yazi.zh.md
+++ b/docs/yazi.zh.md
@@ -1,0 +1,307 @@
+# Yazi
+
+> [English](yazi.md) · 中文
+
+Rust 写的高速 TUI 文件管理器。三栏布局（父目录 / 当前 / 预览）、vim 风键位、原生图片/视频/PDF 预览、内建 `fzf` / `zoxide` / `fd` / `rg` 集成。绑在 `y` 上（是 zsh 函数不是 alias —— 见下）—— 退出 yazi 后 shell 自动 cd 到你最后停留的目录。
+
+## How it works
+
+| 东西 | 位置 | 说明 |
+|---|---|---|
+| 配置 | `~/.config/yazi/yazi.toml` ← 源 `dot_config/yazi/yazi.toml` | 管理器/预览/opener。每次启动重读 —— 无 daemon |
+| Keymap | `~/.config/yazi/keymap.toml` ← 源 `dot_config/yazi/keymap.toml` | `prepend_keymap` 叠在 yazi 默认键位上 |
+| Theme | `~/.config/yazi/theme.toml` ← 源 `dot_config/yazi/theme.toml` | 启用 `catppuccin-mocha` flavor（UI 配色 + 预览语法高亮的 tmTheme）|
+| Init | `~/.config/yazi/init.lua` ← 源 `dot_config/yazi/init.lua` | 插件 bootstrap（`full-border` + `git`）|
+| 插件目录 | `~/.config/yazi/plugins/` | 由 `.chezmoiscripts/run_onchange_after_40-yazi-plugins.sh` 里的 `ya pkg add` 填充。**不入 source** —— 每次 apply 重新生成 |
+| Flavor 目录 | `~/.config/yazi/flavors/` | 同上机制，存完整主题包（`catppuccin-mocha`）。**不入 source** |
+| Shell wrapper | `~/.config/zsh/tools.zsh` → `y()` 函数 | 跑 `yazi --cwd-file=$tmp`，退出时父 shell cd 到 yazi 的最后 CWD |
+| 缓存 | `~/.cache/yazi/` | 图片/视频缩略图。随便删 —— 下次预览自动重建 |
+
+## 核心概念
+
+动手之前理解这几个点能省事：
+
+**两个 binary，一个 brew。** `brew install yazi` 同时安装 `yazi`（TUI）和 `ya`（控制通道 —— 给 `ya pkg` 装插件、`ya emit` 发脚本事件用）。手动调用 `ya` 的场景极少，插件管理会自动用。
+
+**三栏，一组比例。** `[mgr] ratio = [1, 3, 4]` —— 父 / 当前 / 预览。预览最宽是因为图片/视频/代码高亮都在那。光标在预览栏时 `h`/`l` 调宽度。
+
+**Opener 是规则匹配，不是硬编码。** "`<Enter>` 打开文件"不是写死某个命令 —— yazi 从上到下扫 `[open] prepend_rules`，第一个 `mime` / `name` 匹配的赢，它的 `use = [...]` 决定用 `[opener]` 里哪个块。所以我们能让 `.sh` 走 nvim，但其他二进制文件照样交给 macOS Launch Services。
+
+**Plugin vs Flavor。** **Plugin** 加行为（新 previewer、键位、状态列）。**Flavor** 是完整主题包（UI 配色 + 语法高亮 tmTheme）。两者都走 `ya pkg add` 安装。我们装 3 个 plugin（`git` / `smart-enter` / `full-border`）+ 1 个 flavor（`catppuccin-mocha`）—— flavor 让 yazi 的预览语法色和 bat / starship / fastfetch 对齐，终端栈配色统一。
+
+**终端图片协议。** yazi 通过 `$TERM` / `$TERM_PROGRAM` 决定图片渲染协议。Ghostty 原生支持 **Kitty graphics protocol** → 像素级 inline 图，零额外依赖。其他终端静默降级：iTerm2 → iTerm2 协议；tmux 无 passthrough → chafa fallback；Apple Terminal → 无图。
+
+## 5 分钟上手
+
+1. 启动：任意 shell 里打 `y`。
+2. 导航：`j`/`k` 上下，`h` 退出目录，`l` 进目录或打开文件（`smart-enter` 插件）。
+3. 看到一堆目录飞过：`.` 切换隐藏文件显示。
+4. 多选：`space` 单个切换；`v` visual 区间选。
+5. 复制+粘贴：定位到源，`y`，定位到目标，`p`。
+6. 单个 rename：`r`，改名，Enter。
+7. **批量 rename**：多选（`space`）→ `r` → yazi 把所有选中的文件名写进 `$EDITOR` → 逐行改 → 保存 → yazi 按 diff 改名。
+8. 搜索：`/` 当前目录 filename grep；`s` 用 fd 全盘找；`S` 用 rg 全文搜。
+9. 跳转：`z` zoxide（按访问频次）；`Z` fzf（所有目录模糊）。
+10. 用 fzf 找文件并打开：`Z` → 输片段 → Enter → `l`。
+11. 退出：`q` → shell cd 到 yazi 最后停留的目录。`Q` 退出但不 cd。
+
+第 1 步如果报 `command not found`，跑 `chezmoi apply` —— Brewfile + 插件安装都在那一步。
+
+## Keymap 全集
+
+我们的 `keymap.toml` 只覆盖了 `l` / `<Enter>`（交给 `smart-enter`），其余全是 yazi 默认。在 yazi 里按 `~` 可以看实时 help。
+
+### 导航
+
+| 键 | 动作 |
+|---|---|
+| `h` / `j` / `k` / `l` | 左/下/上/右（l = smart-enter） |
+| `gg` / `G` | 顶/底 |
+| `Ctrl+u` / `Ctrl+d` | 半页上/下 |
+| `H` / `L` | 历史后退/前进 |
+| `Tab` | 切到下一 tab |
+| `t` | 在光标位置新开 tab |
+| `1`..`9` | 跳到第 N tab |
+| `[` / `]` | 上/下一个 tab |
+
+### 选择
+
+| 键 | 动作 |
+|---|---|
+| `space` | 光标处切换选中 |
+| `v` | 进入 visual 选择模式 |
+| `Ctrl+a` | 全选当前目录 |
+| `Ctrl+r` | 反选 |
+| `Esc` | 清空选择 |
+
+### 文件操作
+
+| 键 | 动作 |
+|---|---|
+| `y` | 复制（yank）所选 |
+| `x` | 剪切所选 |
+| `p` | 粘贴到当前目录 |
+| `P` | 粘贴并覆盖 |
+| `d` | 移动到回收站 |
+| `D` | 永久删除（不进回收站）|
+| `a` | 新建；末尾 `/` = 新建目录 |
+| `r` | rename（多选 → 批量 rename via `$EDITOR`）|
+| `c` | 复制完整路径到剪贴板（子菜单）|
+
+### 搜索 / 跳转
+
+| 键 | 动作 |
+|---|---|
+| `/` | 当前目录过滤（文件名子串）|
+| `?` | 反向过滤 |
+| `n` / `N` | 下/上一匹配 |
+| `s` | 按文件名搜索（走 `fd`）|
+| `S` | 按内容搜索（走 `rg`）|
+| `z` | zoxide 跳转（需装 zoxide）|
+| `Z` | fzf 跳转（需装 fzf）|
+| `f` / `F` | 当前目录找下/上一个 |
+
+### 预览 / 布局
+
+| 键 | 动作 |
+|---|---|
+| `K` / `J` | 预览栏滚上/下 |
+| `T` | 切换预览栏 |
+| `,` | 排序子菜单（a/c/m/s/e，`r` 反向）|
+| `M` | linemode 子菜单（size / ctime / mtime / 权限 / owner / none）|
+| `.` | 切换隐藏文件 |
+
+### 任务 / shell
+
+| 键 | 动作 |
+|---|---|
+| `w` | 任务管理器（后台拷贝、解压）|
+| `:` | 命令面板（跑 yazi 内部命令）|
+| `!` | 跑 shell 命令，阻塞 yazi |
+| `Shift+!` | 在当前目录开 shell |
+| `Esc` | 关菜单 / 退出模式 |
+| `q` | 退出；shell cd 到 yazi 最后目录 |
+| `Q` | 退出但不 cd |
+
+### Spot（文件元信息面板）
+
+| 键 | 动作 |
+|---|---|
+| （光标对准文件）+ `Tab` | 循环元信息面板（file / EXIF / 链接目标）|
+
+## Shell wrapper `y()`
+
+yazi 作为 "cd 器" 的标准模式。没这个 wrapper，`yazi` 就只是跑起来看看然后退出，你还在原来的目录。有了它：
+
+```zsh
+y() {
+    local tmp cwd
+    tmp="$(mktemp -t 'yazi-cwd.XXXXXX')"
+    yazi "$@" --cwd-file="$tmp"           # yazi 退出时把最后 CWD 写进这个文件
+    if cwd="$(command cat -- "$tmp")" && [[ -n $cwd && $cwd != "$PWD" ]]; then
+        builtin cd -- "$cwd"              # 父 shell 跟过去
+    fi
+    rm -f -- "$tmp"
+}
+```
+
+为什么 `command cat` 和 `builtin cd`：我们 `aliases.zsh` 把 `cat` 绑成 `bat`（带色），zsh 也可能被用户 patch 掉 `cd`。绕开 alias 和函数重载，wrapper 在被别人魔改的环境里也稳。
+
+## 插件 + Flavor
+
+列在 `.chezmoiscripts/run_onchange_after_40-yazi-plugins.sh` 里。加/删一行 → 脚本内容 hash 变 → chezmoi 下次 apply 重跑 → 调 `ya pkg add`。`ya pkg add` 幂等：已装的包静默 skip，重跑成本 ~0。
+
+| 包 | 类型 | 作用 | 怎么接上的 |
+|---|---|---|---|
+| `yazi-rs/plugins:git` | plugin | 文件列表左侧显示 git 状态字符（`M` 改过、`A` 新增、`?` 未跟踪、`!` ignored）| `yazi.toml [plugin.prepend_fetchers]` 注册 fetcher；`init.lua` 调 `require("git"):setup({ order = 1500 })` |
+| `yazi-rs/plugins:smart-enter` | plugin | 统一 `l` + `<Enter>`：目录就 cd 进去，文件就触发 opener。不用再想"这里该按 `l` 还是 `<Enter>`" | `keymap.toml [mgr] prepend_keymap` 把两个键都绑到 `plugin smart-enter` |
+| `yazi-rs/plugins:full-border` | plugin | 三栏外圈加圆角边框。纯视觉 polish | `init.lua` 调 `require("full-border"):setup()`。删掉这一行边框立刻消失 |
+| `yazi-rs/flavors:catppuccin-mocha` | flavor | 完整 UI 配色 + syntect 预览的 tmTheme —— 和 bat（`$BAT_THEME`）、starship、fastfetch 对齐，终端栈整体一套色 | `theme.toml [flavor] dark = "catppuccin-mocha"` |
+
+### git fetcher 语法陷阱
+
+git 插件的 fetcher key 是 `url`，**不是** `name`。yazi 静默接受 `name`，但 fetcher 永远不触发，git glyph 就悄悄没了。如果你发现 gutter 里没 `M`/`A`/`?`，先查 `yazi.toml`：
+
+```toml
+# 正确写法 —— yazi ≥26
+[[plugin.prepend_fetchers]]
+id    = "git"       # yazi > 26.1.22 可省（见插件 README）
+url   = "*"         # ← 是 url，不是 name
+run   = "git"
+group = "git"
+```
+
+`tests/yazi.sh` 的 `fetcher uses url= (not name=)` 回归保护就是针对这个 —— 因为我们第一次上线就踩过。
+
+## 预览后端
+
+yazi 在渲染时按 `$PATH` 探测这些工具。都走 Brewfile 装 —— 缺哪个就该文件类型静默降级成纯文本（或二进制文件根本没预览）。
+
+| 文件类型 | 后端 | Brewfile |
+|---|---|---|
+| 图片 (PNG/JPG/GIF/WebP) | Kitty graphics protocol（built-in）| — |
+| 图片 (HEIC/RAW/冷门格式) | `magick` 转换 → Kitty | `imagemagick` |
+| 视频 (MP4/MOV/MKV) | `ffmpegthumbnailer` 抽首帧 → Kitty | `ffmpegthumbnailer` |
+| PDF | `pdftoppm` 渲首页 → Kitty | `poppler` |
+| 归档 (zip/7z/tar/rar) | `7z l` 列目录 | `sevenzip` |
+| 代码 / 文本 | yazi 内建 syntect —— 按激活的 flavor 的 tmTheme 上色 → 和 bat 一致 | — |
+| JSON | `jq` 美化（yazi built-in）| — |
+| 符号链接 | 目标路径 + 跟穿后预览 | — |
+
+## 改一项
+
+1. 编 `dot_config/yazi/yazi.toml`（或 `keymap.toml` / `init.lua`）。
+2. 无需 reload —— yazi 每次启动重读三个文件。退出 yazi 再 `y` 就好。
+3. 结构性改动（新 section、改 fetcher id），跑 `tests/yazi.sh` 捕捉静默 breakage。
+
+## 加一个插件
+
+1. `.chezmoiscripts/run_onchange_after_40-yazi-plugins.sh` 里加一行：
+
+    ```bash
+    plugins=(
+        "yazi-rs/plugins:git"
+        "yazi-rs/plugins:smart-enter"
+        "yazi-rs/plugins:full-border"
+        "your-user/your-plugin:name"    # ← 新的
+    )
+    ```
+
+2. 如果是 **previewer / fetcher / preloader**，在 `yazi.toml` 里接：
+
+    ```toml
+    [plugin]
+    prepend_previewers = [
+      { mime = "image/*", run = "your-plugin" },
+    ]
+    ```
+
+3. 如果是 **可绑键的命令**，在 `keymap.toml`：
+
+    ```toml
+    [[mgr.prepend_keymap]]
+    on  = "X"
+    run = "plugin your-plugin"
+    ```
+
+4. 如果需要 **启动时 setup**，`init.lua` 里加 `require("your-plugin"):setup()`。
+5. `chezmoi apply` —— `run_onchange` hook 触发，`ya pkg add` 把它装上。
+
+## 健康检查
+
+### 自动化
+
+```bash
+bash tests/yazi.sh
+```
+
+~24 条检查：binary 在 PATH（`yazi`、`ya`）、配置 + keymap + init.lua 存在、TOML 能 parse（python3 ≥ 3.11 时）、关键 section / key 齐全、预览后端可用（`ffmpegthumbnailer`、`magick`、`pdftoppm`、`7z`）、插件目录 `~/.config/yazi/plugins/` 下有货（没 apply 过会 skip 并提示）、Ghostty 检测提示。
+
+### 手动（需要真实 TTY）
+
+1. 新 Ghostty tab 里：`y`。
+2. 三栏布局，带**圆角边框**（`full-border` 插件起效）。
+3. 在 git repo 里逛 —— 修改过的文件左侧挂彩色 `M` / `A` / `?` 字符（`git` 插件）。
+4. `l` 在目录上 → 进入；`l` 在文本文件上 → 打开 nvim（`smart-enter` 插件）。退出 nvim → 回 yazi。
+5. 光标移到 PNG / JPG → 预览显示**真实图片**，不是 ASCII 或 `□`（Kitty 图形协议 OK）。
+6. MP4 → 预览首帧缩略图（ffmpegthumbnailer → Kitty）。
+7. PDF → 预览渲染过的首页（poppler → Kitty）。
+8. 按 `s` 输片段 → fd 实时匹配。
+9. 按 `Z` 输片段 → fzf 全目录模糊。Enter → yazi 跳过去。
+10. `q` 退出 → 外壳 cd 到 yazi 最后目录（`y()` wrapper 起效）。
+
+## Troubleshooting
+
+**`y: command not found`** —— 当前 shell 没 source `tools.zsh`。开新 tab 或 `source ~/.zshrc`。`type y` 应返回函数定义。
+
+**图片预览空白 / `□` / 问号** —— Ghostty Kitty 协议没送到 yazi。检查 `echo $TERM_PROGRAM` 是否 `ghostty`。在 tmux/screen 里没 passthrough 也不会渲染（已知限制 —— yazi 静默不画）。Ghostty 之外需要 chafa 或 sixel 终端，我们没装。
+
+**PDF 预览显示文本 dump** —— `pdftoppm` 缺失。`command -v pdftoppm` 必须有。`brew bundle` 或 `brew install poppler` 补上。
+
+**视频预览空白** —— `ffmpegthumbnailer` 缺失。`brew install ffmpegthumbnailer`。注意：DRM 视频抽不出帧，这类文件本来就不渲。
+
+**Git 状态字符没出来** —— 两种根因：
+  1. 插件没装。查 `ls ~/.config/yazi/plugins/git.yazi` 存在。没有就 `chezmoi apply`。
+  2. fetcher key 写错。`yazi.toml [[plugin.prepend_fetchers]]` 要用 `url = "*"` **不是** `name = "*"` —— yazi ≥26 会静默吃掉 `name`-keyed fetcher。`tests/yazi.sh` 有回归保护；编辑后 glyph 没了就跑一下。
+
+**预览语法色和 bat 不一致** —— flavor 没激活。查 `theme.toml` 有 `[flavor] dark = "catppuccin-mocha"`、`ls ~/.config/yazi/flavors/catppuccin-mocha.yazi` 存在。没 flavor 时 yazi 内建 syntect 走通用深色主题，和 bat 的 Mocha 配色冲突。
+
+**`smart-enter` 不生效** —— 插件没装。查 `~/.config/yazi/plugins/smart-enter.yazi`。没有的话 `chezmoi apply` 触发 `ya pkg add`。
+
+**边框没圆角** —— `full-border` 没装，或 `init.lua` 漏了 `setup()`。确认 `~/.config/yazi/plugins/full-border.yazi` 存在 + `init.lua` 有 `require("full-border"):setup()`。
+
+**`ya pkg add` 第一次 apply 就挂** —— `ya` 在 `yazi` 这个 brew 里。如果 brew install 还没完成，插件 hook 会打印提示并 skip。解法：`brew bundle` → 再 apply。注：yazi ≤0.4 版本的子命令是 `ya pack -a`，本脚本针对 ≥26.x。
+
+**打开 `.sh`/`.py` 蹦出 `Terminal.app` 不是 nvim** —— `[open] prepend_rules` 被跳过。确认 `application/x-shellscript` 那条在 `{ name = "*" }` catch-all 之前。我们 yazi.toml 顺序是对的，改的时候注意别挪到 catch-all 下面。
+
+**批量 rename 打开了奇怪的编辑器** —— yazi 吃 `$EDITOR`。查 `echo $EDITOR` 应是 `nvim`。为空的话批量 rename UI 不弹。
+
+**`y` wrapper 退出后不 cd** —— wrapper 只在 `$cwd` ≠ `$PWD` 时才 cd。如果你在 yazi 里没挪窝直接退出，不 cd 是预期行为。
+
+## Gotchas
+
+**插件安装在 chezmoi 而非 brew 里。** 只跑 `brew bundle` 不会填 `~/.config/yazi/plugins/`。要完整的 `chezmoi apply` 才会触发 `run_onchange_after_40-yazi-plugins.sh` 调 `ya pkg`。
+
+**`run_onchange` hash 的是脚本内容不是插件列表。** 你编辑插件数组 → 脚本体变 → 重跑。但如果你绕过脚本手动 `ya pkg delete <plugin>` 卸了，chezmoi 不知道，下次 apply 不会重装。改脚本（哪怕动个注释）强制重跑。
+
+**`$EDITOR` 必须设了批量 rename 才能用。** yazi 批量 rename 走 `$EDITOR`。我们 `env.zsh` 设了 `EDITOR=nvim` —— 如果丢了（比如 remote session 没传 env），批量 rename 静默 fallback 到坏默认。
+
+**大图预览会爆内存。** `[tasks] image_alloc = 512 MiB` 是硬上限。100MP 以上的图超标，yazi 直接放弃渲染而不是 OOM。调这个值在"安全"和"覆盖面"之间 trade。
+
+**Ghostty 图像协议快速滚动会丢帧。** `[preview] image_delay = 30` ms 是 debounce。调小 → 滚动更跟手；机器慢就调大避免撕裂。
+
+**TOML 解析错误基本上是静默的。** yazi 用坏 config 照样启动，只是忽略崩的 section。`tests/yazi.sh` 在 python3 ≥ 3.11 的机器上做 TOML parse 校验，老 python 只做结构性 grep，留个心眼。
+
+**`plugins/` 不入 chezmoi source。** 插件只在 destination 里。新 Mac clone 这个 repo 跑 `chezmoi apply` 时，`run_onchange` hook 会把它填上。别 `chezmoi add ~/.config/yazi/plugins` —— 会把几 MB 插件源码 vendored 进 repo。
+
+## 从零重建
+
+```bash
+# 删插件缓存 + 缩略图缓存 —— yazi 下次启动自动重建：
+rm -rf ~/.config/yazi/plugins ~/.config/yazi/package.toml ~/.cache/yazi ~/.local/state/yazi
+
+# 再跑一次 apply（或者手动触发 hook）：
+chezmoi apply
+```
+
+`y` 跑起来但没预览？检查：(1) `yazi` 在 PATH（`brew install yazi`），(2) `$TERM_PROGRAM=ghostty`，(3) 预览后端（`ffmpegthumbnailer`、`magick`、`pdftoppm`、`7z`）在 PATH，(4) `~/.config/yazi/plugins/` 下有插件。

--- a/dot_config/yazi/init.lua
+++ b/dot_config/yazi/init.lua
@@ -1,0 +1,18 @@
+-- Yazi init — runs once at launch before the first render.
+--
+-- Boot-order matters: plugins loaded here must be installed via `ya pkg`
+-- first (see .chezmoiscripts/run_onchange_after_40-yazi-plugins.sh).
+-- Order inside this file is cosmetic → doesn't affect correctness.
+
+-- full-border: draw rounded borders around parent/current/preview columns.
+-- Purely visual polish. If you dislike the aesthetic, delete this line
+-- and the borders vanish immediately.
+require("full-border"):setup()
+
+-- git: decorate files with git status glyphs (M/A/D/?/!) in the left gutter
+-- of the current column. The fetcher registered in yazi.toml
+-- ([plugin.prepend_fetchers]) drives the data; this line activates the
+-- status linemode + sets its render order. 1500 is the plugin's own
+-- recommended default (drops it between yazi's built-in size linemode
+-- and user-space linemodes).
+require("git"):setup({ order = 1500 })

--- a/dot_config/yazi/keymap.toml
+++ b/dot_config/yazi/keymap.toml
@@ -1,0 +1,42 @@
+# Yazi — keymap overrides.
+#
+# Schema: https://yazi-rs.github.io/docs/configuration/keymap
+#
+# `prepend_keymap` stacks on top of yazi's defaults — we only list keys
+# we're changing, not re-declaring the whole vocabulary. To see the full
+# default map at runtime, press `~` (help).
+#
+# Philosophy:
+#   - Keep yazi's vim-ish defaults intact. Muscle memory from vim/ranger
+#     works as-is (hjkl, gg/G, y/x/p/d, /, ?, n/N).
+#   - Only override where a plugin plugs in (smart-enter).
+
+[mgr]
+
+# smart-enter — a single `l` / <Enter> that does the right thing:
+#   - On a directory: cd into it
+#   - On a file:      invoke the opener (nvim for text, `open` otherwise)
+# Default yazi ties `l` to `enter` (dir only) and `<Enter>` to `open`, so
+# you'd press different keys depending on cursor position. Annoying.
+prepend_keymap = [
+    { on = "l",       run = "plugin smart-enter", desc = "Enter dir or open file" },
+    { on = "<Enter>", run = "plugin smart-enter", desc = "Enter dir or open file" },
+]
+
+[input]
+# Reserved. Default input-mode keybinds work fine.
+
+[pick]
+# Reserved. Default picker keybinds work fine.
+
+[cmp]
+# Reserved. Default completion keybinds work fine.
+
+[tasks]
+# Reserved. `w` opens task manager; `Ctrl+c` cancels; Esc closes.
+
+[spot]
+# Reserved. `Tab` cycles metadata panes (file / EXIF / linked targets).
+
+[help]
+# Reserved. `~` opens help overlay.

--- a/dot_config/yazi/theme.toml
+++ b/dot_config/yazi/theme.toml
@@ -1,0 +1,18 @@
+# Yazi theme — activates flavor packs.
+#
+# Flavor = a full theme pack (UI palette + syntect tmTheme for preview
+# syntax highlighting). Installed under ~/.config/yazi/flavors/<name>.yazi/
+# by `ya pkg add`, listed in .chezmoiscripts/run_onchange_after_40-yazi-plugins.sh.
+#
+# Catppuccin Mocha keeps the whole terminal stack aligned:
+#   - bat preview via $BAT_THEME        (env.zsh)
+#   - starship prompt palette           (starship.toml)
+#   - fastfetch color bands             (fastfetch/config.jsonc)
+#   - yazi UI + syntect preview         (this file)
+#
+# The flavor ships both a UI palette (border/selection/hover colors) and
+# a tmTheme for syntax-highlighted previews — so markdown/code in the
+# preview pane now matches what `bat` would render.
+
+[flavor]
+dark = "catppuccin-mocha"

--- a/dot_config/yazi/yazi.toml
+++ b/dot_config/yazi/yazi.toml
@@ -29,12 +29,12 @@ wrap          = "no"
 tab_size      = 2
 max_width     = 1000
 max_height    = 1000
-cache_dir     = ""                # Defaults to ~/.cache/yazi — don't override.
 image_delay   = 30                # ms — debounce so rapid `j`/`k` doesn't thrash decoder.
 image_filter  = "triangle"        # Good balance of sharpness vs speed.
 image_quality = 75                # 50–90 is reasonable; 100 is lossless-but-slow.
-ueberzug_scale  = 1
-ueberzug_offset = [0, 0, 0, 0]
+# No ueberzug keys — ueberzug is Linux X11/Wayland only; we preview via
+# Ghostty's Kitty graphics protocol. `cache_dir` omitted so yazi falls
+# back to its default ~/.cache/yazi.
 
 [opener]
 # Unix opener for text → our terminal editor. `block = true` reclaims the
@@ -47,15 +47,15 @@ open = [
     { run = 'open "$@"', desc = "Open", for = "macos" },
 ]
 reveal = [
-    { run = 'open -R "$1"', desc = "Reveal in Finder", for = "macos" },
+    # `"$@"` (not `"$1"`) so multi-select passes every path to `open -R`,
+    # which accepts multiple filenames per `man open`.
+    { run = 'open -R "$@"', desc = "Reveal in Finder", for = "macos" },
 ]
-play = [
-    { run = 'open "$@"', desc = "Play", for = "macos" },
-]
-extract = [
-    # 7z handles zip / 7z / rar / tar.gz via the sevenzip brew.
-    { run = '7z x "$@"', desc = "Extract here", for = "unix" },
-]
+# No `play` / `extract` opener blocks: our `[open] prepend_rules` catch-all
+# routes every non-text file to `open` (Launch Services), which means
+# yazi's default play/extract rules never fire. Defining them here was
+# dead code. Add entries back *with a matching prepend_rule* if you
+# want to peel archives off the catch-all path.
 
 [open]
 # `prepend_rules` stacks above yazi defaults so we can override without

--- a/dot_config/yazi/yazi.toml
+++ b/dot_config/yazi/yazi.toml
@@ -1,0 +1,106 @@
+# Yazi — manager / preview / opener config.
+#
+# Schema: https://yazi-rs.github.io/docs/configuration/yazi
+# Reload: none needed — yazi reads config on every launch.
+#
+# Layout philosophy
+#   Three columns (parent / current / preview) at ratio 1:3:4. The preview
+#   column is the widest because most useful info (image, video thumb, file
+#   content) lives there.
+#
+# Image preview
+#   Ghostty implements the Kitty graphics protocol natively. Yazi detects
+#   $TERM=xterm-ghostty and ships pixel-perfect inline images. No extra
+#   backend (sixel/chafa/überzug) needed on this machine.
+
+[mgr]
+ratio          = [1, 3, 4]
+sort_by        = "natural"        # Explorer-style: file1, file2, file10 (not 1, 10, 2).
+sort_sensitive = false
+sort_reverse   = false
+sort_dir_first = true
+linemode       = "size"           # Right-column meta; toggle via `M` submenu.
+show_hidden    = false            # Toggle live with `.`.
+show_symlink   = true
+scrolloff      = 5
+
+[preview]
+wrap          = "no"
+tab_size      = 2
+max_width     = 1000
+max_height    = 1000
+cache_dir     = ""                # Defaults to ~/.cache/yazi — don't override.
+image_delay   = 30                # ms — debounce so rapid `j`/`k` doesn't thrash decoder.
+image_filter  = "triangle"        # Good balance of sharpness vs speed.
+image_quality = 75                # 50–90 is reasonable; 100 is lossless-but-slow.
+ueberzug_scale  = 1
+ueberzug_offset = [0, 0, 0, 0]
+
+[opener]
+# Unix opener for text → our terminal editor. `block = true` reclaims the
+# TTY so nvim can own the screen; yazi resumes when nvim exits.
+edit = [
+    { run = 'nvim "$@"', desc = "nvim", block = true, for = "unix" },
+]
+# macOS default: hand to Launch Services. `open foo.pdf` → Preview.app, etc.
+open = [
+    { run = 'open "$@"', desc = "Open", for = "macos" },
+]
+reveal = [
+    { run = 'open -R "$1"', desc = "Reveal in Finder", for = "macos" },
+]
+play = [
+    { run = 'open "$@"', desc = "Play", for = "macos" },
+]
+extract = [
+    # 7z handles zip / 7z / rar / tar.gz via the sevenzip brew.
+    { run = '7z x "$@"', desc = "Extract here", for = "unix" },
+]
+
+[open]
+# `prepend_rules` stacks above yazi defaults so we can override without
+# having to re-declare every MIME yazi already handles.
+prepend_rules = [
+    # Text + code families → our editor, not Launch Services. (Finder would
+    # open a .sh in TextEdit which is never what you want.) Listed one MIME
+    # per line because yazi's glob matcher doesn't do brace-expansion.
+    { mime = "text/*",                       use = [ "edit", "reveal" ] },
+    { mime = "application/json",             use = [ "edit", "reveal" ] },
+    { mime = "application/x-yaml",           use = [ "edit", "reveal" ] },
+    { mime = "application/x-shellscript",    use = [ "edit", "reveal" ] },
+    { mime = "application/xml",              use = [ "edit", "reveal" ] },
+    { mime = "application/toml",             use = [ "edit", "reveal" ] },
+    # Catch-all fallback — Launch Services. macOS knows best for binary types.
+    { name = "*",                                    use = [ "open", "reveal" ] },
+    { name = "*/",                                   use = [ "open", "reveal" ] },
+]
+
+[tasks]
+micro_workers    = 10
+macro_workers    = 10
+bizarre_retry    = 3
+# Image memory guard — oversized pics get downsized before render so yazi
+# doesn't OOM on a 60MP shot.
+image_alloc      = 536_870_912     # 512 MiB
+image_bound      = [0, 0]
+suppress_preload = false
+
+[plugin]
+# fetcher = runs on every directory enter to decorate the file list.
+# `url` (not `name`) is the pattern field in yazi ≥26; `id` stays for
+# ≤26.1.22 backcompat (the git plugin README says it's safe to remove
+# on newer). `group = "git"` namespaces the fetcher so status updates
+# fan out correctly across nested dirs.
+prepend_fetchers = [
+    { id = "git", url = "*",  run = "git", group = "git" },
+    { id = "git", url = "*/", run = "git", group = "git" },
+]
+
+[input]
+# Confirm dialogs — keep key ratio + position at yazi defaults. Reserved
+# here as the first place to look when you want to tweak dialog layout.
+
+[which]
+sort_by        = "none"
+sort_sensitive = false
+sort_reverse   = false

--- a/dot_config/zsh/tools.zsh
+++ b/dot_config/zsh/tools.zsh
@@ -21,3 +21,22 @@ fi
 if (( $+commands[starship] )); then
     eval "$(starship init zsh)"
 fi
+
+# yazi: `y` drops you into the TUI and, on quit, cd's the outer shell
+# to wherever yazi last was. This is the canonical shell integration
+# from https://yazi-rs.github.io/docs/quick-start — keeps yazi usable
+# as a fuzzy cd tool, not just a viewer.
+#
+# `command cat` bypasses our `cat=bat` alias (see aliases.zsh) so the
+# temp file is read raw, not prettified.
+if (( $+commands[yazi] )); then
+    y() {
+        local tmp cwd
+        tmp="$(mktemp -t 'yazi-cwd.XXXXXX')"
+        yazi "$@" --cwd-file="$tmp"
+        if cwd="$(command cat -- "$tmp")" && [[ -n $cwd && $cwd != "$PWD" ]]; then
+            builtin cd -- "$cwd"
+        fi
+        rm -f -- "$tmp"
+    }
+fi

--- a/tests/yazi.sh
+++ b/tests/yazi.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Non-interactive yazi health check. ~1s. Covers binary presence, config
+# parseability, plugin install state, and backend availability. Visual
+# fidelity (image preview, borders, git gutter) is Manual-only —
+# see docs/yazi.md → Health check → Manual.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$1"; PASS=$((PASS+1)); }
+bad() { printf "  \033[31m✗\033[0m %s\n" "$1"; [[ -n ${2:-} ]] && printf "    %s\n" "$2"; FAIL=$((FAIL+1)); }
+
+check() {
+    local name=$1 cmd=$2 out
+    if out=$(eval "$cmd" 2>&1); then ok "$name"; else bad "$name" "$out"; fi
+}
+
+YZDIR="$HOME/.config/yazi"
+CFG="$YZDIR/yazi.toml"
+KEYMAP="$YZDIR/keymap.toml"
+THEME="$YZDIR/theme.toml"
+INIT="$YZDIR/init.lua"
+TOOLS="$HOME/.config/zsh/tools.zsh"
+
+echo "── Binaries on PATH ─────────────────────────────────"
+check "yazi on PATH"                             "command -v yazi >/dev/null"
+check "ya (companion) on PATH"                   "command -v ya >/dev/null"
+
+echo
+echo "── File presence ────────────────────────────────────"
+check "yazi.toml present"                        "test -r $CFG"
+check "keymap.toml present"                      "test -r $KEYMAP"
+check "theme.toml present"                       "test -r $THEME"
+check "init.lua present"                         "test -r $INIT"
+check "zsh y() wrapper in tools.zsh"             "grep -q 'yazi.*--cwd-file' $TOOLS"
+
+echo
+echo "── TOML parses ──────────────────────────────────────"
+# Python 3.11+ ships tomllib; earlier macOS CLT python3 (3.9) doesn't.
+# When absent, skip parse-validation — structural grep below still catches
+# obvious breakage (missing section headers).
+if python3 -c 'import tomllib' 2>/dev/null; then
+    check "yazi.toml parses as TOML"             "python3 -c 'import tomllib; tomllib.load(open(\"$CFG\",\"rb\"))'"
+    check "keymap.toml parses as TOML"           "python3 -c 'import tomllib; tomllib.load(open(\"$KEYMAP\",\"rb\"))'"
+    check "theme.toml parses as TOML"            "python3 -c 'import tomllib; tomllib.load(open(\"$THEME\",\"rb\"))'"
+else
+    ok "TOML parse check skipped (python3 lacks tomllib, needs ≥3.11)"
+fi
+
+echo
+echo "── Expected sections / keys ─────────────────────────"
+# Catches accidental section deletions during refactors. Each section
+# here backs a real feature referenced by the docs — if one goes missing,
+# the docs are lying.
+for sect in '\[mgr\]' '\[preview\]' '\[opener\]' '\[open\]' '\[tasks\]' '\[plugin\]'; do
+    check "yazi.toml has $sect"                  "grep -qE '^$sect' $CFG"
+done
+check "yazi.toml: fetcher 'git' registered"      "grep -q 'id = \"git\"' $CFG"
+# url (not name) is the yazi ≥26 pattern key — using `name` made the fetcher
+# silently no-op, which is how we shipped broken git-status on the first cut.
+check "yazi.toml: fetcher uses url= (not name=)" "grep -q 'url = \"\\*\"' $CFG"
+check "keymap: smart-enter bound"                "grep -q 'plugin smart-enter' $KEYMAP"
+check "init.lua: full-border setup"              "grep -q 'full-border' $INIT"
+check "init.lua: git setup"                      "grep -q 'require(\"git\")' $INIT"
+check "theme.toml: flavor activated"             "grep -qE '^dark *=' $THEME"
+
+echo
+echo "── Preview backends on PATH ─────────────────────────"
+# yazi auto-detects these by PATH; missing ones silently degrade
+# (e.g. no PDF → text fallback). Flag loudly here — the brewfile
+# should keep them present.
+check "ffmpegthumbnailer (video thumb)"          "command -v ffmpegthumbnailer >/dev/null"
+check "magick (imagemagick fallback)"            "command -v magick >/dev/null"
+check "pdftoppm (poppler, PDF preview)"          "command -v pdftoppm >/dev/null"
+check "7z (sevenzip, archive list)"              "command -v 7z >/dev/null || command -v 7zz >/dev/null"
+
+echo
+echo "── Plugins + flavor installed ───────────────────────"
+# Plugins land under plugins/, flavors under flavors/ — both populated
+# by `ya pkg install`. If the post-apply hook hasn't run yet, skip
+# cleanly — docs explain how.
+PLUG="$YZDIR/plugins"
+FLAV="$YZDIR/flavors"
+if [[ -d $PLUG ]]; then
+    for plug in git smart-enter full-border; do
+        # ya pkg unpacks into <name>.yazi/
+        check "plugin $plug installed"           "test -d $PLUG/$plug.yazi"
+    done
+else
+    ok "plugins dir not yet created — run 'chezmoi apply' then re-test"
+fi
+if [[ -d $FLAV ]]; then
+    check "flavor catppuccin-mocha installed"    "test -d $FLAV/catppuccin-mocha.yazi"
+else
+    ok "flavors dir not yet created — run 'chezmoi apply' then re-test"
+fi
+
+echo
+echo "── Terminal image protocol ──────────────────────────"
+# Yazi auto-picks a protocol based on \$TERM/\$TERM_PROGRAM. Ghostty =
+# Kitty graphics protocol. If tests run from Apple Terminal or a tmux
+# session without passthrough, previews silently fall back to chafa/none.
+if [[ ${TERM_PROGRAM:-} == "ghostty" ]] || [[ ${TERM:-} == "xterm-ghostty" ]]; then
+    ok "running in Ghostty (TERM=$TERM) — image preview will use Kitty protocol"
+else
+    ok "not in Ghostty (TERM=${TERM:-?}) — image preview untested; run 'y' in Ghostty"
+fi
+
+echo
+echo "─────────────────────────────────────────────────────"
+if (( FAIL > 0 )); then
+    printf "  \033[31m%d passed, %d failed\033[0m\n" $PASS $FAIL
+    echo
+    echo "  Visual fidelity (image preview, rounded borders, git gutter"
+    echo "  glyphs) is NOT covered here — run 'y' in a real Ghostty tab"
+    echo "  and walk the Manual checklist in docs/yazi.md."
+    exit 1
+fi
+printf "  \033[32m%d passed, %d failed\033[0m\n" $PASS $FAIL
+echo
+echo "  Config + plugin logic OK. Visual still needs a real TTY —"
+echo "  see docs/yazi.md → Health check → Manual."


### PR DESCRIPTION
## Summary / 概述

- Phase 4d drops yazi onto `y` (zsh wrapper `cd`s outer shell back to yazi's last dir on quit); image / video / PDF preview runs inline via Ghostty's Kitty graphics protocol with no sixel/chafa fallback required.
- Three plugins (`git` status gutter, `smart-enter` unifying `l` + `<Enter>`, `full-border` rounded panes) plus `catppuccin-mocha` flavor align yazi's preview syntax colors with bat / starship / fastfetch — one palette across the stack.
- Plugin + flavor install happens in `.chezmoiscripts/run_onchange_after_40-yazi-plugins.sh` via yazi ≥26's `ya pkg add`; 29-check `tests/yazi.sh` guards TOML shape, backends on PATH, install state, and the `url=` vs `name=` fetcher gotcha that silently killed git glyphs on the first cut.
- Bilingual docs (`docs/yazi.{md,zh.md}`) cover concepts, the full default keymap by category, the `y()` wrapper, every plugin + flavor we ship, all preview backends, troubleshooting, and gotchas — deep by request since user is new to yazi.

## Change type / 变更类型

- [x] `feat` — new package / functionality · 新包或新功能
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`

## Checklist / 检查清单

- [x] Commit messages follow Conventional Commits · Commit 信息符合 Conventional Commits
- [x] `pre-commit run --all-files` passes locally · 本地跑过 `pre-commit run --all-files` 且全绿
- [x] `chezmoi diff` reviewed; no surprising deletions or permission changes · 已 review `chezmoi diff`，没有意外的删除或权限变化
- [x] New CLI tool → added to `Brewfile` · 新 CLI 工具已加入 `Brewfile`（yazi + ffmpegthumbnailer + imagemagick + poppler + sevenzip）
- [x] Smoke-tested end-to-end on at least one Mac · 在至少一台 Mac 上做过端到端冒烟（Ghostty tab 里 `y` 走过 Manual checklist — 三栏 Mocha 配色、git glyph、smart-enter、图片/PDF 预览、quit cd）

## Notes for reviewer / 给 reviewer 的说明

**The `url` vs `name` fetcher gotcha.** The git plugin README spells out `url = "*"`; yazi ≥26 silently accepts `name = "*"` too but the fetcher never fires. First cut shipped with `name=` — user's manual smoke spotted missing gutter glyphs. `tests/yazi.sh` now has a regression guard (`fetcher uses url= (not name=)`) so this can't slide back in.

**`ya pack` → `ya pkg` rename.** yazi 26.1 renamed the plugin subcommand. The install script targets the new API, with a comment pointing at the older form in case someone pins an old brew.

**Plugin install is a chezmoi hook, not a brew step.** `brew bundle` alone populates binaries but leaves `~/.config/yazi/{plugins,flavors}/` empty. `chezmoi apply` runs the `run_onchange` hook which invokes `ya pkg add` for each listed plugin/flavor. Gotchas section in the docs calls this out.

**exiftool opener removed.** An early draft had `{ run = 'exiftool "$1"; ...', desc = "Show EXIF", block = true, ... }` as a second entry under `[opener] reveal`, but the inline-table-across-two-lines form fails `check-toml`. Rather than install exiftool just to satisfy the TOML spec, dropped it — EXIF curiosity can lean on Spotlight's Get Info for now.

**Out of scope:** nvim integration (Phase 7), custom opener stacks beyond text/macOS-default split, per-filetype previewer plugins. Future customization to land via issues per user request.

_Generated with Claude Code._
