### PR TITLE
feat(ghostty): tmux-prefix chord keybinds + Mocha theme + Maple font pin

### DIFF
--- a/docs/ghostty.md
+++ b/docs/ghostty.md
@@ -1,0 +1,213 @@
+# Ghostty
+
+> English · [中文](ghostty.zh.md)
+
+GPU-accelerated macOS terminal by Mitchell Hashimoto. Picked over iTerm2/Alacritty/WezTerm because its native **splits + tabs + quick-terminal + Kitty image protocol** cover the workflows that used to need tmux. With Claude Code increasingly assumed to run in a single-process terminal, removing tmux removes a whole layer of "who owns my clipboard / image protocol / keybind".
+
+## How it works
+
+| Thing | Where | Note |
+|---|---|---|
+| Config | `~/.config/ghostty/config` ← source `dot_config/ghostty/config` | Single file, `key = value`. Reloaded by `ctrl+s > r` or on next launch. |
+| Binary + app | `/Applications/Ghostty.app`, CLI at `/opt/homebrew/bin/ghostty` | Installed via `cask "ghostty"` in Brewfile. |
+| Font | `Maple Mono NF CN` | Installed via `cask "font-maple-mono-nf-cn"`. Same font is pinned by starship (Phase 4a). |
+| Theme | `Catppuccin Mocha` (built-in) | No flavor install needed — shipped inside Ghostty's `+list-themes`. |
+| Scrollback | In-memory ring buffer | `scrollback-limit = 10000` lines per surface. No on-disk persistence. |
+
+## Why these choices
+
+**Why no tmux?** Ghostty's native tabs + splits replace tmux's windows + panes, `window-save-state = always` replaces `tmux-resurrect`, and the Kitty graphics protocol replaces `tmux` image-passthrough headaches. One less layer between the shell and the GPU = faster redraws + working image preview in yazi.
+
+**Why `ctrl+s` as chord prefix?** Three constraints collided:
+1. **Karabiner** on this machine maps `Ctrl+h/j/k/l → arrow keys` globally. Any bare `ctrl+hjkl` binding in Ghostty is dead on arrival.
+2. User prefers `Ctrl` over `Cmd` on HHKB (Ctrl sits where Caps Lock does — home-row pinky).
+3. User's long-standing tmux prefix was `ctrl+s`.
+Chord prefix resolves all three: the second key after `ctrl+s` is a bare letter, which Karabiner ignores. Ghostty intercepts `ctrl+s` before the PTY, so the historical terminal XOFF (freeze output) never fires.
+
+**Why `Maple Mono NF CN` (not Italic)?** Starship (Phase 4a) needs NF glyphs (powerline triangles, MDI mac icon, feedback glyphs); zsh source inside this repo is ASCII so CN CJK coverage never hurts. Italic-as-body makes plain text slightly noisier — we want upright body + italic-on-demand for code spans that explicitly request italic.
+
+## Quick start (2-min tour)
+
+1. **Launch**: open Ghostty from Spotlight, or hit `⌘ + \`` anywhere to drop down the quick-terminal.
+2. **Prefix**: `Ctrl+s`. Hold ctrl, tap s, release both, then tap the next key. ~1s timeout.
+3. **Split right**: `Ctrl+s  |` (shift+backslash). **Split down**: `Ctrl+s  -`.
+4. **Navigate splits**: `Ctrl+s  h/j/k/l` — matches vim; Karabiner-safe because post-chord.
+5. **New tab**: `Ctrl+s  c`. **Close surface** (split or tab): `Ctrl+s  x`.
+6. **Zoom current split full-screen**: `Ctrl+s  z`. Repeat to un-zoom.
+7. **Reload this file**: edit, then `Ctrl+s  r`. No restart.
+
+If any key does nothing, see [Troubleshooting](#troubleshooting) — usually Karabiner eats it.
+
+## Keymap reference
+
+Prefix is `Ctrl+s`. All chord bindings are "prefix, then the listed key". Bare bindings (no prefix) call out `[global]` or `[bare]`.
+
+### Tabs (≈ tmux windows)
+
+| Keys | Action |
+|---|---|
+| `c` | new tab |
+| `n` / `p` | next / previous tab |
+| `1`..`9` | go to tab N |
+| `x` | close current surface (also works on splits) |
+
+### Splits (≈ tmux panes)
+
+| Keys | Action |
+|---|---|
+| `\|` (shift+`\`) | split right |
+| `-` | split down |
+| `h` / `j` / `k` / `l` | move focus left / down / up / right |
+| `z` | toggle zoom (current split full-screen) |
+| `=` | equalize all splits |
+| `x` | close current split |
+
+### Misc
+
+| Keys | Action |
+|---|---|
+| `r` | reload `~/.config/ghostty/config` |
+| `[` | scroll to top of scrollback |
+
+### Global / Ghostty defaults (no prefix)
+
+| Keys | Action |
+|---|---|
+| `⌘ + \`` | toggle quick-terminal drop-down (global — works from other apps) |
+| `⌘ + c` / `⌘ + v` | copy / paste (default) |
+| `⌘ + +` / `⌘ + -` / `⌘ + 0` | font size up / down / reset (default) |
+| mouse drag | select + auto-copy to clipboard (`copy-on-select = clipboard`) |
+
+## Feature deep-dives
+
+### Quick-terminal (`⌘ + \``)
+
+Global drop-down from the top of the screen with mouse-follow (whichever monitor has the cursor). Hits anywhere, auto-hides on focus loss. Meant for throwaway commands: `curl ifconfig.me`, quick `grep`, `calc` via `python -c`. Settings:
+
+- `quick-terminal-position = top` — slides from top edge
+- `quick-terminal-screen = mouse` — uses the display the cursor is on
+- `quick-terminal-autohide = true` — disappears when you click elsewhere
+- `quick-terminal-animation-duration = 0.15` — snappy, not sluggish
+
+### `window-save-state = always`
+
+On quit, Ghostty serializes current tab/split layout + cwd + shell history position. On relaunch, everything restores. Great when the Mac sleeps/reboots — long `cargo build`s or `claude-code` sessions resume in place.
+
+### Shell integration (`shell-integration = detect`)
+
+Ghostty auto-injects a preamble when it detects zsh/bash/fish. Unlocks:
+- **Cwd reporting**: new splits / tabs inherit the current directory.
+- **Prompt-hook marks**: jump to start of prompts with `jump_to_prompt` (not currently bound; add `keybind = ctrl+s>u=jump_to_prompt_previous` if wanted).
+- **Exit status awareness**: enables future features like "color cursor by last exit code".
+
+### Clipboard paste protection
+
+`clipboard-paste-protection = true` means pasting text that looks dangerous (contains newlines or control chars) pops a confirmation. Stops the classic `curl example.com/install.sh | sudo bash`-from-paste accident. `clipboard-paste-bracketed-safe = true` disables bracketed paste for shells/apps that don't advertise support — prevents garbled input when you paste into something primitive.
+
+### Transparent titlebar + blur
+
+`macos-titlebar-style = transparent` + `background-opacity = 0.8` + `background-blur-radius = 20` → content sits on a frosted-glass layer. Your wallpaper stays as a soft anchor, the window stops being a big opaque slab. If you feel transparency hurts contrast, bump `background-opacity = 0.9` (closer to opaque).
+
+## Change a setting
+
+1. Edit `~/.config/ghostty/config` (or `dot_config/ghostty/config` in this repo and `chezmoi apply`).
+2. In an open Ghostty: `Ctrl+s r`. No restart.
+3. If the change is invalid, Ghostty prints an error in a banner but keeps the previous value — nothing breaks silently.
+4. To verify from CLI without launching Ghostty: `ghostty +validate-config --config-file=~/.config/ghostty/config`.
+
+## Add a keybind
+
+Ghostty chord syntax: `keybind = ctrl+s>KEY=ACTION[:ARG]`. Examples:
+
+```
+# Ctrl+s then w → write scrollback to a file
+keybind = ctrl+s>w=write_scrollback_file
+
+# Ctrl+s then b → previous prompt (shell-integration hook)
+keybind = ctrl+s>b=jump_to_prompt:-1
+
+# Global (works from any app): Cmd+option+space → quick-terminal
+keybind = global:cmd+opt+space=toggle_quick_terminal
+```
+
+List all actions: `ghostty +list-actions`. List themes: `ghostty +list-themes`. List fonts: `ghostty +list-fonts`.
+
+**Avoid bare `ctrl+hjkl`** — Karabiner on this machine intercepts them before Ghostty sees them. Put them behind the chord prefix.
+
+## Health check
+
+### Automated
+```bash
+bash tests/ghostty.sh
+```
+Exits 0 iff every item below is green: `ghostty` on PATH, config parses, chord prefix wired to hjkl + c + x + r, no stray bare `ctrl+hjkl`, Maple font + Mocha theme discoverable by Ghostty. ~1 second.
+
+### Manual (needs a real Ghostty window — visual fidelity)
+- [ ] **Theme**: colors match `bat test.md` output. Background is Mocha's `base` (#1e1e2e), not plain black.
+- [ ] **Font**: powerline triangles in starship prompt render without gaps. CJK text (`echo 你好`) aligns to cell boundary, not half-width-squished.
+- [ ] **Transparency + blur**: wallpaper visible through window, slightly frosted (not sharp).
+- [ ] **Titlebar**: no visible chrome strip at top — titlebar blends into background.
+- [ ] **Quick-terminal**: `⌘ + \`` from any app drops a slim terminal from the top; `⌘ + \`` again or click-away dismisses it.
+- [ ] **Chord prefix**: `Ctrl+s  c` opens a new tab. `Ctrl+s  |` opens a right-split. `Ctrl+s  h/l` jumps between them.
+- [ ] **Zoom**: `Ctrl+s  z` makes the focused split fill the tab; `Ctrl+s  z` again restores.
+- [ ] **Karabiner coexist**: bare `Ctrl+h` inside any split moves cursor one char left (arrow key behavior), not deletes-word. If it deletes, Karabiner's rule is off — check `~/.config/karabiner/`.
+- [ ] **Reload**: edit config (change `font-size = 13`), `Ctrl+s  r`, font resizes without reopening.
+- [ ] **Quit + restart**: open two tabs with a split each, `⌘ + q`, relaunch → layout restored.
+- [ ] **Image preview** (via yazi): `y` → pick a `.png` or `.jpg` → preview pane renders the actual image, not a text placeholder.
+
+## Troubleshooting
+
+**Chord doesn't fire (pressing `Ctrl+s` then a key does nothing)**
+- Timeout: Ghostty drops the prefix ~1s after `Ctrl+s`. Press the second key faster.
+- Another app grabbed `Ctrl+s`: check System Settings → Keyboard → Shortcuts, or Karabiner rules.
+- Config typo: run `ghostty +validate-config --config-file=~/.config/ghostty/config`; fix any reported line.
+
+**`Ctrl+s` freezes my shell output**
+- Shouldn't happen — Ghostty intercepts the keybind before the PTY. If it does, the config isn't applying. Reload with `Ctrl+s  r` or restart Ghostty.
+- If you added a pass-through (`ctrl+s>ctrl+s=text:\x13`), that sends literal XOFF. Run `stty -ixon` in the affected shell to disable flow control, or remove the pass-through.
+
+**Font looks blurry / has gaps**
+- `ghostty +list-fonts | grep "^Maple Mono NF CN$"` — if empty, the cask hasn't installed the font. Run `chezmoi apply` (triggers `brew bundle`) or `brew install --cask font-maple-mono-nf-cn`.
+- If font is listed but Ghostty renders it wrong: `atsutil databases -remove` (purges macOS font cache), relaunch Ghostty.
+
+**Quick-terminal doesn't drop from global hotkey**
+- System Settings → Privacy & Security → Accessibility → Ghostty must be allowed (grants global hotkey capture).
+- Another app binds `⌘ + \``: change `keybind = global:cmd+grave_accent=...` in config.
+
+**Image preview in yazi shows placeholder instead of image**
+- Verify `TERM`: `echo $TERM` should print `xterm-ghostty`. If `xterm-256color` (our forced value), yazi still sniffs `TERM_PROGRAM=ghostty` and uses Kitty protocol. Check `echo $TERM_PROGRAM`.
+- If running through `ssh` / `tmux`, neither layer passes through the Kitty graphics protocol without extra config. Use Ghostty directly for image preview.
+
+**Chezmoi apply doesn't update live Ghostty**
+- Ghostty watches the config file: changes apply on next launch OR on `Ctrl+s  r`. `chezmoi apply` writes the file; Ghostty only re-reads it when you reload.
+
+## Gotchas
+
+- **No `tmux` here** — if you muscle-memory `Ctrl+b c` for a new window, it won't do anything. Prefix is `Ctrl+s`.
+- **`Ctrl+s` prefix conflicts with literal XOFF only if you bypass Ghostty** — happens inside `ssh` to a server (the server sees `Ctrl+s` pre-PTY freeze), NOT in local Ghostty splits. On remote sessions, either run `stty -ixon` on login, or use `Cmd+s`-shaped bindings for remote work.
+- **Tab numbers `1..9` reach tabs 1-9 only** — no `0` for tab 10. If you end up with ≥10 tabs, use `Ctrl+s  n/p` to walk.
+- **Equalize splits (`Ctrl+s  =`) balances the tree, not the visible pane** — in a nested split tree, `=` resets all sizes to even, not just the current level.
+- **`copy-on-select = clipboard` overwrites the pasteboard on every mouse drag** — no separate "selection" buffer on macOS, so if you drag-select to re-read something, you lose whatever was previously copied. Use `Cmd+c` intentionally if the current clipboard matters.
+
+## Rebuild from scratch
+
+Fresh Mac or fresh `~/.config`:
+
+```bash
+# 1. Install via cask (brew bundle covers it via Brewfile)
+brew install --cask ghostty font-maple-mono-nf-cn
+
+# 2. Drop the config into place
+chezmoi apply   # writes ~/.config/ghostty/config from dot_config/ghostty/config
+
+# 3. Launch Ghostty once so macOS registers it
+open -a Ghostty
+
+# 4. First-time accessibility permission (for global quick-terminal hotkey)
+#    System Settings → Privacy & Security → Accessibility → enable Ghostty
+
+# 5. Validate
+bash tests/ghostty.sh
+```
+
+If `tests/ghostty.sh` passes, walk the Manual checklist above to confirm visual fidelity — the automated tests can't see color/blur/transparency.

--- a/docs/ghostty.zh.md
+++ b/docs/ghostty.zh.md
@@ -1,0 +1,214 @@
+# Ghostty
+
+> 中文 · [English](ghostty.md)
+
+Mitchell Hashimoto 做的 GPU 加速 macOS 终端。选它而非 iTerm2/Alacritty/WezTerm 的原因：原生 **splits + tabs + quick-terminal + Kitty 图像协议**，覆盖了以前需要 tmux 的场景。Claude Code 越来越默认跑在单进程终端里，移除 tmux = 移除一整层"谁拥有我的剪贴板 / 图像协议 / 快捷键"的不确定性。
+
+## 组件分布
+
+| 组件 | 位置 | 说明 |
+|---|---|---|
+| 配置 | `~/.config/ghostty/config` ← 源 `dot_config/ghostty/config` | 单文件 `key = value`。`ctrl+s > r` 重载，或下次启动生效。 |
+| 二进制 + app | `/Applications/Ghostty.app`，CLI 在 `/opt/homebrew/bin/ghostty` | Brewfile 里 `cask "ghostty"` 装。 |
+| 字体 | `Maple Mono NF CN` | 通过 `cask "font-maple-mono-nf-cn"` 装。和 starship（Phase 4a）锁同一个。 |
+| 主题 | `Catppuccin Mocha`（内置） | 不需要额外 flavor 安装 —— `ghostty +list-themes` 里自带。 |
+| Scrollback | 内存环形缓冲 | `scrollback-limit = 10000` 行/surface。不落盘。 |
+
+## 为什么这么选
+
+**为什么不用 tmux？** Ghostty 原生 tabs + splits 替代 tmux 的 windows + panes，`window-save-state = always` 替代 `tmux-resurrect`，Kitty 图像协议替代 tmux 的图像透传痛点。shell 和 GPU 之间少一层 = 重绘更快 + yazi 图像预览直接能用。
+
+**为什么 `ctrl+s` 做 chord 前缀？** 三个约束交汇：
+1. 本机 **Karabiner** 全局把 `Ctrl+h/j/k/l` 映射成方向键。Ghostty 里任何裸 `ctrl+hjkl` 绑定都拿不到信号。
+2. HHKB 布局下用户更喜欢 `Ctrl`（位于 Caps Lock 位 —— 小指本位）而非 `Cmd`。
+3. 用户此前 tmux prefix 就是 `ctrl+s`，肌肉记忆已在。
+
+Chord 前缀一次性解决三者：`ctrl+s` 之后的键是单字母，Karabiner 不拦；Ghostty 在 PTY 之前拦截 keybind，所以历史上 `ctrl+s` 触发的 XOFF（冻结输出）在这里不会发生。
+
+**为什么 `Maple Mono NF CN`（非斜体）？** Starship（Phase 4a）需要 NF 字形（powerline 三角、MDI mac 图标、feedback 字符）；本仓库 zsh 源都是 ASCII，所以 CN 的 CJK 覆盖不会有坏处。正文斜体会让纯文本略显杂乱 —— 我们希望正文保持正体，需要斜体的代码段自己声明。
+
+## 两分钟上手
+
+1. **启动**：Spotlight 打开 Ghostty，或者在任何地方按 `⌘ + \`` 唤出下拉式 quick-terminal。
+2. **Prefix**：`Ctrl+s`。按住 ctrl 点 s，松开两者，然后点下一个键。超时约 1 秒。
+3. **左右分屏**（新分屏在右）：`Ctrl+s  |`（shift+backslash）。**上下分屏**（新分屏在下）：`Ctrl+s  -`。
+4. **分屏间跳**：`Ctrl+s  h/j/k/l` —— 和 vim 一致；因为在 chord 之后，Karabiner 不干扰。
+5. **新 tab**：`Ctrl+s  c`。**关闭当前 surface**（分屏或 tab）：`Ctrl+s  x`。
+6. **当前分屏最大化**：`Ctrl+s  z`。再按一次取消。
+7. **重载配置**：编辑本文件后 `Ctrl+s  r`。无需重启。
+
+某个键无反应？见 [排错](#排错) —— 通常是 Karabiner 先吃掉了。
+
+## 键位表
+
+前缀 `Ctrl+s`。所有 chord 绑定 = "先按前缀，再按列出的键"。无前缀的会标注 `[global]`。
+
+### Tabs（≈ tmux windows）
+
+| 键 | 动作 |
+|---|---|
+| `c` | 新 tab |
+| `n` / `p` | 下一个 / 上一个 tab |
+| `1`..`9` | 跳到第 N 个 tab |
+| `x` | 关闭当前 surface（分屏也适用） |
+
+### Splits（≈ tmux panes）
+
+| 键 | 动作 |
+|---|---|
+| `\|`（shift+`\`） | 左右分屏（新分屏在右） |
+| `-` | 上下分屏（新分屏在下） |
+| `h` / `j` / `k` / `l` | 焦点向左 / 下 / 上 / 右移 |
+| `z` | 切换最大化（当前分屏占满 tab） |
+| `=` | 均分所有分屏 |
+| `x` | 关闭当前分屏 |
+
+### 杂项
+
+| 键 | 动作 |
+|---|---|
+| `r` | 重载 `~/.config/ghostty/config` |
+| `[` | 滚动到 scrollback 顶部 |
+
+### 全局 / Ghostty 默认（无前缀）
+
+| 键 | 动作 |
+|---|---|
+| `⌘ + \`` | 切换 quick-terminal 下拉（全局 —— 其他 app 里也响应） |
+| `⌘ + c` / `⌘ + v` | 复制 / 粘贴（默认） |
+| `⌘ + +` / `⌘ + -` / `⌘ + 0` | 字号增 / 减 / 重置（默认） |
+| 鼠标拖选 | 选中即复制到剪贴板（`copy-on-select = clipboard`） |
+
+## 特性细节
+
+### Quick-terminal（`⌘ + \``）
+
+屏幕顶部下拉，跟随鼠标所在屏幕（多显示器时很方便）。任意 app 里唤起，失焦自动隐藏。适合一次性命令：`curl ifconfig.me`、临时 `grep`、用 `python -c` 当计算器。配置：
+
+- `quick-terminal-position = top` —— 从顶边滑下
+- `quick-terminal-screen = mouse` —— 用光标所在显示器
+- `quick-terminal-autohide = true` —— 点别处就隐藏
+- `quick-terminal-animation-duration = 0.15` —— 干脆不拖泥带水
+
+### `window-save-state = always`
+
+退出时 Ghostty 序列化当前 tab/split 布局 + cwd + shell 历史位置。下次启动原样恢复。Mac 睡眠/重启时很好用 —— 长 `cargo build` 或 `claude-code` 会话接着用。
+
+### Shell 集成（`shell-integration = detect`）
+
+Ghostty 检测到 zsh/bash/fish 后自动注入前导脚本。解锁：
+- **Cwd 汇报**：新分屏/tab 继承当前目录。
+- **Prompt-hook 标记**：可以 `jump_to_prompt` 跳到上一个 prompt（默认未绑定；如需，加 `keybind = ctrl+s>u=jump_to_prompt_previous`）。
+- **退出码感知**：为后续"根据上次退出码改光标颜色"这类功能铺路。
+
+### 剪贴板粘贴保护
+
+`clipboard-paste-protection = true` —— 粘贴看起来危险的内容（含换行或控制字符）时弹窗确认。挡住经典的"粘贴 `curl example.com/install.sh | sudo bash` 意外触发"。`clipboard-paste-bracketed-safe = true` 让不声明支持的 shell/app 走非 bracketed paste —— 防止粘贴到老旧程序里乱码。
+
+### 透明标题栏 + 模糊
+
+`macos-titlebar-style = transparent` + `background-opacity = 0.8` + `background-blur-radius = 20` —— 内容像浮在磨砂玻璃上。壁纸保留为柔和背景，窗口不是一整块不透明板。觉得透明伤对比度：把 `background-opacity` 调到 `0.9`。
+
+## 改一个设置
+
+1. 编辑 `~/.config/ghostty/config`（或本仓库 `dot_config/ghostty/config` 后 `chezmoi apply`）。
+2. 在开着的 Ghostty 里：`Ctrl+s r`。无需重启。
+3. 改得不合法：Ghostty 会横幅报错但保留旧值 —— 不会静默崩坏。
+4. CLI 验证（不启动 Ghostty）：`ghostty +validate-config --config-file=~/.config/ghostty/config`。
+
+## 加一个快捷键
+
+Chord 语法：`keybind = ctrl+s>KEY=ACTION[:ARG]`。例子：
+
+```
+# Ctrl+s 再按 w → 把 scrollback 写入文件
+keybind = ctrl+s>w=write_scrollback_file
+
+# Ctrl+s 再按 b → 跳到上一个 prompt（需要 shell-integration）
+keybind = ctrl+s>b=jump_to_prompt:-1
+
+# 全局（任意 app 里响应）：Cmd+option+space → quick-terminal
+keybind = global:cmd+opt+space=toggle_quick_terminal
+```
+
+列出所有动作：`ghostty +list-actions`。列主题：`ghostty +list-themes`。列字体：`ghostty +list-fonts`。
+
+**避免裸 `ctrl+hjkl`** —— 本机 Karabiner 在 Ghostty 看到之前就拦截了。放到 chord 前缀后面。
+
+## 健康检查
+
+### 自动化
+```bash
+bash tests/ghostty.sh
+```
+返回 0 当且仅当下面全部绿：`ghostty` 在 PATH、配置能解析、chord 前缀绑定了 hjkl/c/x/r、无残留裸 `ctrl+hjkl`、Maple 字体 + Mocha 主题可被 Ghostty 发现。~1 秒。
+
+### 手动（需要一个真的 Ghostty 窗口 —— 视觉保真）
+- [ ] **主题**：颜色和 `bat test.md` 输出一致。背景是 Mocha 的 `base`（#1e1e2e），不是纯黑。
+- [ ] **字体**：starship prompt 的 powerline 三角无缝衔接。CJK（`echo 你好`）对齐到单元格边界，不是半宽压扁。
+- [ ] **透明 + 模糊**：能看到壁纸，略磨砂（不是清晰）。
+- [ ] **标题栏**：顶部没有可见 chrome 条 —— 标题栏融进背景。
+- [ ] **Quick-terminal**：从任意 app 按 `⌘ + \`` 从顶部落下细条终端；再按或点别处消失。
+- [ ] **Chord 前缀**：`Ctrl+s  c` 开新 tab。`Ctrl+s  |` 左右分屏。`Ctrl+s  h/l` 切换焦点。
+- [ ] **最大化**：`Ctrl+s  z` 让焦点分屏占满 tab；再按恢复。
+- [ ] **Karabiner 共存**：任意分屏里按裸 `Ctrl+h` —— 光标左移一字符（方向键行为），不是删前一个词。如果是删词，说明 Karabiner 规则没生效 —— 看 `~/.config/karabiner/`。
+- [ ] **重载**：改配置（`font-size = 13`），`Ctrl+s  r`，字体立刻变大不用重开。
+- [ ] **退出重启**：两个 tab 各带分屏，`⌘ + q` 退出，重开 —— 布局复原。
+- [ ] **图像预览**（yazi）：`y` → 选个 `.png`/`.jpg` → 预览栏渲染真实图像，不是文本占位符。
+
+## 排错
+
+**Chord 没反应（按 `Ctrl+s` 再按键没动静）**
+- 超时：`Ctrl+s` 之后 ~1 秒丢弃前缀。第二键按快点。
+- 被其他 app 抢走 `Ctrl+s`：看系统设置 → 键盘 → 快捷键，或 Karabiner 规则。
+- 配置笔误：跑 `ghostty +validate-config --config-file=~/.config/ghostty/config`，按报错改。
+
+**`Ctrl+s` 冻住了 shell 输出**
+- 理论上不会 —— Ghostty 在 PTY 之前拦截 keybind。若真发生，说明配置没生效。`Ctrl+s  r` 或重启 Ghostty。
+- 如果你加了透传（`ctrl+s>ctrl+s=text:\x13`），那就是发了字面 XOFF。在受影响 shell 里跑 `stty -ixon` 关流控，或删掉透传。
+
+**字体发虚 / 有缝**
+- `ghostty +list-fonts | grep "^Maple Mono NF CN$"` —— 空就是 cask 没装成。`chezmoi apply`（触发 brew bundle）或直接 `brew install --cask font-maple-mono-nf-cn`。
+- 字体列出来了但 Ghostty 渲染错位：`atsutil databases -remove`（清 macOS 字体缓存），重启 Ghostty。
+
+**Quick-terminal 全局热键不响应**
+- 系统设置 → 隐私与安全 → 辅助功能 → 允许 Ghostty（全局热键捕获需要）。
+- 被其他 app 占用 `⌘ + \``：改配置里 `keybind = global:cmd+grave_accent=...`。
+
+**yazi 图像预览显示占位符而非图像**
+- 看 `TERM`：`echo $TERM` 应该是 `xterm-ghostty`。如果是 `xterm-256color`（我们强制的值），yazi 会 sniff `TERM_PROGRAM=ghostty` 来判定 Kitty 协议，看 `echo $TERM_PROGRAM`。
+- 经 `ssh` / `tmux` 转发的话，两层都不原生透传 Kitty 图像协议。图像预览请在本地 Ghostty 里用。
+
+**Chezmoi apply 没更新在开的 Ghostty**
+- Ghostty 不主动 watch 配置文件：下次启动或 `Ctrl+s  r` 才重读。`chezmoi apply` 只是改文件。
+
+## 踩坑
+
+- **这里没有 tmux** —— 肌肉记忆 `Ctrl+b c` 开新 window 会毫无反应。前缀是 `Ctrl+s`。
+- **`Ctrl+s` 前缀只在绕过 Ghostty 时才触发字面 XOFF** —— `ssh` 到服务器时会发生（服务器端在 PTY 前看到 `Ctrl+s` 冻住），本地 Ghostty 分屏里不会。远程 session 里，要么登录后跑 `stty -ixon`，要么远程工作用 `Cmd+s`-形状的绑定。
+- **Tab 号 `1..9` 只覆盖 1-9** —— 没有 `0` 到第 10 个 tab。≥10 个 tab 用 `Ctrl+s  n/p` 走。
+- **均分分屏（`Ctrl+s  =`）均整棵树而非当前层** —— 嵌套分屏树里，`=` 把所有尺寸重置为均等，不只当前层。
+- **`copy-on-select = clipboard` 每次鼠标拖选都覆盖剪贴板** —— macOS 上没有独立的 selection buffer，所以如果你拖选一下只是想重读一遍，剪贴板里之前的东西就没了。重要内容用 `Cmd+c` 主动留。
+
+## 从零重建
+
+全新 Mac 或空 `~/.config`：
+
+```bash
+# 1. cask 安装（brew bundle 通过 Brewfile 覆盖）
+brew install --cask ghostty font-maple-mono-nf-cn
+
+# 2. 配置到位
+chezmoi apply   # 从 dot_config/ghostty/config 写到 ~/.config/ghostty/config
+
+# 3. 启动一次让 macOS 登记
+open -a Ghostty
+
+# 4. 首次辅助功能权限（quick-terminal 全局热键）
+#    系统设置 → 隐私与安全 → 辅助功能 → 勾选 Ghostty
+
+# 5. 验证
+bash tests/ghostty.sh
+```
+
+`tests/ghostty.sh` 通过后，再走一遍手动 checklist 确认视觉保真 —— 自动测试看不见颜色/模糊/透明度。

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,0 +1,162 @@
+# Ghostty config — kickstart style, heavy inline commentary.
+#
+# Reload:  ctrl+s then r   (chord; see keybinds below)
+# Verify:  ghostty +validate-config --config-file=$HOME/.config/ghostty/config
+# Reset:   comment out any stanza and reload — ghostty falls back to defaults.
+#
+# Layout:
+#   1. Appearance  (theme / font / padding)
+#   2. Window      (titlebar / save-state / cursor)
+#   3. Shell       (integration, mouse, clipboard)
+#   4. Quick term  (global drop-down)
+#   5. Keybinds    (tmux-style ctrl+s prefix chord)
+
+
+# =============================================================================
+# 1. Appearance
+# =============================================================================
+
+# Ghostty ships Catppuccin Mocha as a built-in theme — no extra install needed.
+# Keeping this identical to bat / starship / yazi / fastfetch Mocha palette so
+# the whole terminal stack reads as one visual surface.
+theme = Catppuccin Mocha
+
+# xterm-256color is the portable choice. Ghostty's own xterm-ghostty terminfo
+# is richer (truecolor + image protocol advertised) but many servers lack it,
+# and Ghostty auto-upgrades capabilities locally either way.
+term = xterm-256color
+
+# Maple Mono NF CN: NF = Nerd Font (powerline + mdi glyphs for starship's
+# mac-icon + feedback modules). CN = full CJK coverage. We lock upright (not
+# Italic) as the body face so plain text stays neutral; italics still apply
+# to code spans that request an italic style.
+font-family = Maple Mono NF CN
+font-size = 12
+font-thicken = true
+adjust-cell-height = 2
+
+# Translucent + blurred background on macOS — keeps focus on content while
+# the wallpaper stays as a soft visual anchor. 0.8 is the sweet spot: enough
+# transparency to breathe, still readable over light wallpapers.
+background-opacity = 0.8
+background-blur-radius = 20
+
+window-padding-x = 10
+window-padding-y = 10
+
+
+# =============================================================================
+# 2. Window
+# =============================================================================
+
+# `transparent` gives a seamless edge on macOS — the titlebar becomes a thin
+# strip with no visible chrome, matching the blurred background.
+macos-titlebar-style = transparent
+
+# Ghostty restores split/tab layout on relaunch. Good for long-running shells
+# (claude-code sessions, long builds); cheap to disable per-window via cmd+q.
+window-save-state = always
+window-theme = auto
+
+cursor-style = bar
+cursor-style-blink = true
+cursor-opacity = 0.8
+
+
+# =============================================================================
+# 3. Shell / input / clipboard
+# =============================================================================
+
+# `detect` → ghostty injects shell integration when it recognizes the shell
+# (zsh/bash/fish). Unlocks prompt-hook marks (for `jump_to_prompt`), cwd
+# reporting (new splits inherit cwd), and exit-status-aware behavior.
+shell-integration = detect
+
+mouse-hide-while-typing = true
+
+# copy-on-select mirrors tmux/iTerm behavior — select with mouse, paste with
+# cmd+v without an explicit copy. Ghostty writes to the system clipboard
+# (not just a selection buffer) so paste works even after switching apps.
+copy-on-select = clipboard
+
+scrollback-limit = 10000
+
+# Paste safety — warns when pasted text looks like it contains newlines or
+# control sequences a shell would execute. Catches "curl | bash"-shaped
+# mistakes where a multiline URL triggers immediately on paste.
+clipboard-paste-protection = true
+clipboard-paste-bracketed-safe = true
+
+
+# =============================================================================
+# 4. Quick terminal  (macOS drop-down from top, global hotkey)
+# =============================================================================
+
+# Used for one-off commands without switching windows — e.g. "what's my IP",
+# "run a grep in a scratch dir". Auto-hides on focus loss so it doesn't
+# clutter the active workspace.
+quick-terminal-position = top
+quick-terminal-screen = mouse
+quick-terminal-autohide = true
+quick-terminal-animation-duration = 0.15
+
+
+# =============================================================================
+# 5. Keybinds — tmux-style chord (ctrl+s prefix)
+# =============================================================================
+#
+# Why chord, not bare ctrl+<key>?
+#   - Karabiner maps Ctrl+h/j/k/l → arrow keys globally, so bare ctrl+hjkl
+#     can't be used here. Chord prefix isolates hjkl behind ctrl+s, so the
+#     second key is a bare letter that Karabiner leaves alone.
+#   - Preserves shell readline (ctrl+a / ctrl+e / ctrl+w) and vim ctrl+<key>
+#     motions — chord prefix steals only ctrl+s, nothing else.
+#
+# Why ctrl+s (not ctrl+a / ctrl+b)?
+#   - Matches prior tmux muscle memory for this user.
+#   - ctrl+s historically triggered terminal XOFF (freeze output). Ghostty
+#     intercepts keybinds BEFORE the PTY sees them, so ctrl+s-as-prefix
+#     never freezes anything here. (If you ever want literal ctrl+s sent to
+#     a foreground app, add a pass-through: `ctrl+s>ctrl+s=text:\x13`.)
+#
+# Chord timeout: Ghostty waits ~1s after the prefix for the next key. Type
+# nothing and the prefix is dropped silently — no stuck-modifier state.
+
+# ---- Global (not chord — toggles even when Ghostty isn't focused) -----------
+keybind = global:cmd+grave_accent=toggle_quick_terminal
+
+# ---- Tabs (≈ tmux windows) --------------------------------------------------
+keybind = ctrl+s>c=new_tab
+keybind = ctrl+s>n=next_tab
+keybind = ctrl+s>p=previous_tab
+keybind = ctrl+s>one=goto_tab:1
+keybind = ctrl+s>two=goto_tab:2
+keybind = ctrl+s>three=goto_tab:3
+keybind = ctrl+s>four=goto_tab:4
+keybind = ctrl+s>five=goto_tab:5
+keybind = ctrl+s>six=goto_tab:6
+keybind = ctrl+s>seven=goto_tab:7
+keybind = ctrl+s>eight=goto_tab:8
+keybind = ctrl+s>nine=goto_tab:9
+
+# ---- Splits (≈ tmux panes) --------------------------------------------------
+# | and - picked for visual mnemonics: | = vertical divider (split right),
+# - = horizontal divider (split down). Matches tmux's `bind |` / `bind -`.
+keybind = ctrl+s>shift+backslash=new_split:right
+keybind = ctrl+s>minus=new_split:down
+
+# hjkl navigation inside chord — Karabiner doesn't intercept post-chord keys.
+keybind = ctrl+s>h=goto_split:left
+keybind = ctrl+s>j=goto_split:bottom
+keybind = ctrl+s>k=goto_split:top
+keybind = ctrl+s>l=goto_split:right
+
+keybind = ctrl+s>z=toggle_split_zoom
+keybind = ctrl+s>equal=equalize_splits
+
+# x = close the current surface (split OR tab, whichever is focused).
+keybind = ctrl+s>x=close_surface
+
+# ---- Misc -------------------------------------------------------------------
+keybind = ctrl+s>r=reload_config
+keybind = ctrl+s>left_bracket=scroll_to_top

--- a/tests/ghostty.sh
+++ b/tests/ghostty.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Non-interactive ghostty health check. ~1s. Covers binary presence, config
+# parseability, keybind integrity (chord prefix + no bare ctrl+hjkl that
+# Karabiner would steal), and font/theme availability. Visual fidelity
+# (blur, transparent titlebar, quick-terminal drop-down, image preview in
+# yazi) is Manual-only — see docs/ghostty.md → Health check → Manual.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$1"; PASS=$((PASS+1)); }
+bad() { printf "  \033[31m✗\033[0m %s\n" "$1"; [[ -n ${2:-} ]] && printf "    %s\n" "$2"; FAIL=$((FAIL+1)); }
+
+check() {
+    local name=$1 cmd=$2 out
+    if out=$(eval "$cmd" 2>&1); then ok "$name"; else bad "$name" "$out"; fi
+}
+
+CFG="$HOME/.config/ghostty/config"
+
+echo "── Binary + app ─────────────────────────────────────"
+check "ghostty on PATH"                         "command -v ghostty >/dev/null"
+check "Ghostty.app installed"                   "test -d /Applications/Ghostty.app"
+
+echo
+echo "── Config presence + syntax ─────────────────────────"
+check "config present"                          "test -r $CFG"
+# Ghostty's own validator is authoritative — catches typos, unknown actions,
+# bad enum values, malformed chords. Exits non-zero on any error.
+check "ghostty +validate-config passes"         "ghostty +validate-config --config-file=$CFG"
+
+echo
+echo "── Appearance fields ────────────────────────────────"
+# Each of these backs a visible claim in docs/ghostty.md. If someone deletes
+# a line during refactor, the docs start lying — flag here.
+check "theme = Catppuccin Mocha"                "grep -qE '^theme *= *Catppuccin Mocha' $CFG"
+check "font-family = Maple Mono NF CN"          "grep -qE '^font-family *= *Maple Mono NF CN\$' $CFG"
+check "font-size = 12"                          "grep -qE '^font-size *= *12\$' $CFG"
+check "background-opacity set"                  "grep -qE '^background-opacity *= *0\\.[0-9]+' $CFG"
+check "macos-titlebar-style = transparent"      "grep -qE '^macos-titlebar-style *= *transparent' $CFG"
+
+echo
+echo "── Keybinds: chord prefix integrity ─────────────────"
+# Regression guards for the tmux-style chord scheme:
+#   1. Prefix must be ctrl+s (if someone changes it, they should also update docs).
+#   2. hjkl navigation must live BEHIND the prefix, not as bare ctrl+hjkl —
+#      Karabiner remaps ctrl+hjkl → arrow keys globally, so a bare binding
+#      would never fire inside ghostty.
+check "prefix chord ctrl+s>... present"         "grep -qE '^keybind *= *ctrl\\+s>' $CFG"
+check "chord: ctrl+s>h = goto_split:left"       "grep -qE '^keybind *= *ctrl\\+s>h *= *goto_split:left' $CFG"
+check "chord: ctrl+s>j = goto_split:bottom"     "grep -qE '^keybind *= *ctrl\\+s>j *= *goto_split:bottom' $CFG"
+check "chord: ctrl+s>k = goto_split:top"        "grep -qE '^keybind *= *ctrl\\+s>k *= *goto_split:top' $CFG"
+check "chord: ctrl+s>l = goto_split:right"      "grep -qE '^keybind *= *ctrl\\+s>l *= *goto_split:right' $CFG"
+check "chord: ctrl+s>c = new_tab"               "grep -qE '^keybind *= *ctrl\\+s>c *= *new_tab' $CFG"
+check "chord: ctrl+s>x = close_surface"         "grep -qE '^keybind *= *ctrl\\+s>x *= *close_surface' $CFG"
+check "chord: ctrl+s>r = reload_config"         "grep -qE '^keybind *= *ctrl\\+s>r *= *reload_config' $CFG"
+check "global: cmd+grave → quick_terminal"      "grep -qE '^keybind *= *global:cmd\\+grave_accent *= *toggle_quick_terminal' $CFG"
+
+# Karabiner conflict guard: no line binds bare ctrl+{h,j,k,l}=... (would be
+# a live grenade — the key never reaches ghostty). chord form `ctrl+s>h`
+# contains `>` before the letter, so the negation below ignores those.
+check "no bare ctrl+hjkl binding (karabiner)"   "! grep -qE '^keybind *= *ctrl\\+[hjkl] *=' $CFG"
+
+echo
+echo "── Font + theme availability ────────────────────────"
+# `ghostty +list-fonts` reads the active font cache; if Maple isn't
+# listed, cask "font-maple-mono-nf-cn" hasn't applied yet or font cache
+# needs a refresh (atsutil databases -remove + relaunch ghostty).
+#
+# Capture-then-match (not `grep -q` on the pipe) because `ghostty +list-*`
+# output is long and grep -q exits on first match → ghostty dies with
+# SIGPIPE → `set -o pipefail` fails the whole check. Reading into a var
+# first drains ghostty cleanly.
+_fonts=$(ghostty +list-fonts 2>/dev/null || true)
+_themes=$(ghostty +list-themes 2>/dev/null || true)
+check "font 'Maple Mono NF CN' available"       "grep -q '^Maple Mono NF CN\$' <<<\"\$_fonts\""
+check "theme 'Catppuccin Mocha' available"      "grep -q 'Catppuccin Mocha' <<<\"\$_themes\""
+
+echo
+echo "── Runtime context ──────────────────────────────────"
+# Informational — helps debug when tests run from a non-ghostty shell.
+if [[ ${TERM_PROGRAM:-} == "ghostty" ]] || [[ ${TERM:-} == "xterm-ghostty" ]]; then
+    ok "running inside Ghostty (TERM=$TERM) — visual tests possible"
+else
+    ok "not inside Ghostty (TERM=${TERM:-?}) — walk docs Manual checklist in a real Ghostty tab"
+fi
+
+echo
+echo "─────────────────────────────────────────────────────"
+if (( FAIL > 0 )); then
+    printf "  \033[31m%d passed, %d failed\033[0m\n" $PASS $FAIL
+    echo
+    echo "  Visual fidelity (blur, transparent titlebar, quick-terminal"
+    echo "  drop-down, chord prefix timing) is NOT covered here — open"
+    echo "  Ghostty and walk the Manual checklist in docs/ghostty.md."
+    exit 1
+fi
+printf "  \033[32m%d passed, %d failed\033[0m\n" $PASS $FAIL
+echo
+echo "  Config + keybind logic OK. Visual still needs a real window —"
+echo "  see docs/ghostty.md → Health check → Manual."


### PR DESCRIPTION
<!--
Title should follow Conventional Commits: `<type>(<scope>?): <subject>`
标题遵循 Conventional Commits
-->

## Summary / 概述

Greenfield Ghostty config replacing the copy-paste-from-web baseline. Ships Catppuccin Mocha theme (built-in, no flavor install), `Maple Mono NF CN` upright body (closes Phase 4a starship's manual font-pin), and a tmux-style `ctrl+s` chord prefix for tabs/splits tuned around this machine's Karabiner layout (bare `ctrl+hjkl` can't be used). Phase 4 closes out with this — 4a/4b/4c/4d all in.

全新 Ghostty 配置，替换之前从网上拷的 baseline。统一 Catppuccin Mocha 主题（内置，无需装 flavor），用 `Maple Mono NF CN` 正体正文（闭环 Phase 4a starship 留的字体手动步骤），tmux 风格 `ctrl+s` chord 前缀管理 tabs/splits，针对本机 Karabiner（裸 `ctrl+hjkl` 被映射成方向键）做了规避。Phase 4 至此全部闭环（4a/4b/4c/4d）。

## Change type / 变更类型

- [x] `feat` — new package / functionality · 新包或新功能
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`

## Checklist / 检查清单

- [x] Commit messages follow Conventional Commits · Commit 信息符合 Conventional Commits
- [x] `pre-commit run --all-files` passes locally · 本地跑过 `pre-commit run --all-files` 且全绿
- [x] `chezmoi diff` reviewed; no surprising deletions or permission changes · 已 review `chezmoi diff`，无意外
- [x] New package → entry added to the `Layout` section of `README.md` · README Layout 是目录树非包列表，Brewfile 已含 `cask "ghostty"` + `cask "font-maple-mono-nf-cn"`，无需变更
- [x] New CLI tool → added to `Brewfile` · 无新 CLI（Ghostty 本就在 Brewfile，未加新依赖）
- [x] Smoke-tested end-to-end on at least one Mac · `tests/ghostty.sh` 22/22 通过；手动验证了 chord 前缀 + reload + quick-terminal + yazi 图像预览

## Notes for reviewer / 给 reviewer 的说明

**Why `ctrl+s` chord (not bare ctrl+X or cmd-based) —** three constraints collided and only chord resolves them all:

1. **Karabiner ctrl+hjkl → arrow keys.** Any bare `ctrl+hjkl` binding inside Ghostty is dead on arrival — Karabiner intercepts before Ghostty sees it. Behind a chord prefix, the second key is a bare letter, which Karabiner ignores. Test file's `no bare ctrl+hjkl binding (karabiner)` guard encodes this.
2. **HHKB ergonomics.** User prefers `ctrl` (home-row pinky at caps-lock position) over `cmd` (hyper-key = option globally via Karabiner, so option+cmd combos get misfired easily).
3. **Existing muscle memory.** User's tmux prefix was `ctrl+s` — reusing it means zero relearning.

The historical `ctrl+s = XOFF` concern is a non-issue here: Ghostty intercepts keybinds before the PTY, so the prefix never freezes anything.

**What's NOT in this PR —** quick-terminal size, cursor smooth-trail, and `quick-terminal-position = center` were discussed but deferred per user preference ("先维持现状"). Ghostty 1.3.1 doesn't expose `quick-terminal-size` and has no cursor-trail config key; those are upstream gaps, not configuration debt. User can open issues once they find concrete friction.

**Scope —** config + tests + bilingual docs. No Brewfile / README / scripts touched (Ghostty cask + Maple font already in Brewfile from earlier phases). Phase 4 is now fully closed.

_Generated with Claude Code._
