### PR TITLE
feat(git): per-machine identity + lazygit + gh + XDG_CONFIG_HOME

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -10,3 +10,8 @@ Brewfile
 .github
 docs
 tests
+
+# Phase 6a: gh hosts.yml holds per-machine auth state (user, token path
+# — oauth_token itself is in macOS Keychain, but don't risk it). Never
+# track; ignore pre-emptively in case the file lands in source.
+dot_config/gh/hosts.yml

--- a/docs/git.md
+++ b/docs/git.md
@@ -1,6 +1,6 @@
-# Git
+# Git & companion tools
 
-Minimal global git config plus a short global ignore file. Identity switches per machine via the `is_work` chezmoi prompt — no `includeIf`, no per-directory rules.
+Minimal global git config + global ignore, plus `lazygit` (TUI) and `gh` (CLI). Identity switches per machine via the `is_work` chezmoi prompt — no `includeIf`, no per-directory rules.
 
 ---
 
@@ -10,8 +10,12 @@ Minimal global git config plus a short global ignore file. Identity switches per
 |---|---|---|
 | `dot_gitconfig.tmpl` | `~/.gitconfig` | Identity switched by `is_work`; shared knobs (delta, rebase, conflict style, …) are the same on every machine |
 | `dot_gitignore_global` | `~/.gitignore_global` | Referenced from `core.excludesFile` |
+| `dot_config/lazygit/config.yml` | `~/.config/lazygit/config.yml` | Catppuccin Mocha theme + delta pager + nvim edit |
+| `dot_config/gh/config.yml` | `~/.config/gh/config.yml` | PR-heavy aliases (`pv`, `pl`, `pc`, `pm`, …) |
 
 chezmoi renders the template on each `chezmoi apply` — no hook scripts needed.
+
+> **Note on lazygit's config path.** macOS lazygit defaults to `~/Library/Application Support/lazygit/`. We set `XDG_CONFIG_HOME="$HOME/.config"` in `dot_zshenv` so lazygit (and every XDG-aware tool) reads `~/.config/` instead — same as Linux. Verify with `lazygit --print-config-dir` (expected: `~/.config/lazygit`).
 
 ---
 
@@ -60,6 +64,39 @@ Shell aliases for git live in `dot_config/zsh/aliases.zsh` (Phase 3): `gst`, `gc
 
 ---
 
+## lazygit
+
+Kickstart-style 80%-useful config — customize as real needs emerge.
+
+- **Theme:** Catppuccin Mocha, same palette as ghostty / yazi / starship (`#89b4fa` blue active border, `#313244` selection background, …)
+- **Pager:** `delta --paging=never` so lazygit's diff pane matches `git diff` output
+- **Editor:** `nvim` via `os.edit` / `os.editAtLine` — `e` on a file in the staging pane opens it at the right line
+- **Other:** file tree on, random tip off, mouse events on, nerd fonts v3
+
+Runtime note: lazygit **does not** read `~/.gitconfig` `[alias]` entries; lazygit's own keymap drives the TUI. Keep custom git aliases in `~/.gitconfig` for shell use.
+
+---
+
+## gh (GitHub CLI)
+
+Only non-default values are in `config.yml`; unset keys fall back to gh's built-in defaults. Verify with `gh config list`.
+
+Aliases optimized for the PR-review loop:
+
+| Alias | Expands to | Use case |
+|---|---|---|
+| `gh co` | `pr checkout` | Pull a PR locally for testing |
+| `gh pv` | `pr view` | Read PR body + comments in terminal (`-w` for browser) |
+| `gh pl` | `pr list` | See open PRs |
+| `gh pc` | `pr checks` | CI status for the current branch's PR |
+| `gh pm` | `pr merge` | Merge (use `--squash` / `--rebase` per repo policy) |
+| `gh prs` | `pr status` | PRs involving you (authored / assigned / review-requested) |
+| `gh il` / `gh iv` | `issue list` / `issue view` | Issue equivalents |
+
+> **`hosts.yml` is NOT tracked.** It holds per-machine auth state (username + keyring path; the oauth token itself lives in macOS Keychain). `.chezmoiignore` pre-emptively excludes `dot_config/gh/hosts.yml` in case it ever lands in source.
+
+---
+
 ## Change / Add a setting
 
 1. Edit `dot_gitconfig.tmpl` (or `dot_gitignore_global`).
@@ -85,6 +122,9 @@ Covers: binary presence, target-file presence, every pinned setting under `[core
 - [ ] `git diff <some-file-with-changes>` renders through delta (side-by-side, line numbers visible)
 - [ ] `git lg -5` shows a colored graph
 - [ ] Cloning a fresh HTTPS repo prompts for credentials once, then caches via Keychain
+- [ ] `lazygit --print-config-dir` returns `~/.config/lazygit` (not `~/Library/…`)
+- [ ] `lazygit` opens with Mocha-blue borders and delta-rendered diffs
+- [ ] `gh pv` / `gh pc` run from any dir and target the current repo's PR
 - [ ] On the **other** machine after `chezmoi apply`: `user.email` is the other identity
 
 ---
@@ -98,6 +138,8 @@ Covers: binary presence, target-file presence, every pinned setting under `[core
 | `fatal: unknown style 'zdiff3'` | git < 2.35 | `brew upgrade git` |
 | Delta not invoked on `git diff` | `delta` missing from PATH | `brew install git-delta` |
 | `interactive.diffFilter` noise when stdin is not a tty | Expected: it only triggers interactively | Not a bug |
+| lazygit ignores `~/.config/lazygit/config.yml` | `XDG_CONFIG_HOME` not exported in current shell | Open a new zsh (reads `dot_zshenv`), or `export XDG_CONFIG_HOME=$HOME/.config` manually |
+| `gh` asks to re-auth on a machine that was logged in | `hosts.yml` missing (never tracked) | `gh auth login` — runs once per machine |
 
 ---
 

--- a/docs/git.md
+++ b/docs/git.md
@@ -1,0 +1,121 @@
+# Git
+
+Minimal global git config plus a short global ignore file. Identity switches per machine via the `is_work` chezmoi prompt — no `includeIf`, no per-directory rules.
+
+---
+
+## How it works
+
+| Source (repo) | Target (`$HOME`) | Behavior |
+|---|---|---|
+| `dot_gitconfig.tmpl` | `~/.gitconfig` | Identity switched by `is_work`; shared knobs (delta, rebase, conflict style, …) are the same on every machine |
+| `dot_gitignore_global` | `~/.gitignore_global` | Referenced from `core.excludesFile` |
+
+chezmoi renders the template on each `chezmoi apply` — no hook scripts needed.
+
+---
+
+## Why these choices
+
+1. **Identity per machine, not per directory.** Historical plan mentioned `includeIf "gitdir:~/personal/"`; dropped because the user's actual habit is "whichever Mac I'm on, commit as that Mac." Same repo cloned on both machines authors under different identities automatically.
+2. **`delta` as pager + `interactive.diffFilter`.** Side-by-side, line numbers, navigate (n/N between hunks) — installed in Phase 2's Brewfile (`git-delta`). When piping to a script, override with `-c core.pager=cat`.
+3. **`merge.conflictstyle = zdiff3`.** Shows the common ancestor in conflict markers — dramatically easier three-way merges than default `merge` style. Requires git ≥ 2.35 (Brewfile pulls latest).
+4. **`rebase.autoStash = true`.** `git pull --rebase` on a dirty tree auto-stashes instead of erroring. Saves a manual `git stash` / `git stash pop` every time.
+5. **No `pull.rebase` pin.** zsh `OMZP::git` plugin provides `gl`/`gp` shortcuts; explicit pull strategy stays a per-repo decision. Git's default (merge) is kept.
+6. **Minimal aliases.** `OMZP::git` already ships `gst` / `gco` / `gcb` / … Only `lg` (pretty graph log) stays in `~/.gitconfig` because it's longer than an alias can cleanly be.
+7. **`credential.helper = osxkeychain`.** macOS Keychain for HTTPS credentials. For GitHub specifically, `gh auth login` installs its own credential helper in front of this — both work.
+
+---
+
+## Identity per machine
+
+| Machine | `is_work` | `user.name` | `user.email` |
+|---|---|---|---|
+| Work Mac | `true` | `zyz` | `zhongyuzhe@bytedance.com` |
+| Personal Mac | `false` | `Kyrie` | `yuzhezhong0117@qq.com` |
+
+The values live inside `dot_gitconfig.tmpl` guarded by `{{ if .is_work }} … {{ else }} … {{ end }}`. `is_work` is prompted once at `chezmoi init` and stored in `~/.config/chezmoi/chezmoi.toml`. To flip it, re-run `chezmoi init` (or edit the toml directly and `chezmoi apply`).
+
+---
+
+## Alias reference
+
+Git aliases kept in `~/.gitconfig`:
+
+| Alias | Expands to |
+|---|---|
+| `git lg` | `log --graph --pretty=format:'%C(auto)%h%d %s %C(blue)(%cr) %C(bold blue)<%an>' --abbrev-commit` |
+
+Shell aliases for git live in `dot_config/zsh/aliases.zsh` (Phase 3): `gst`, `gco`, `gcb`, `gcm`, `ga`, `gaa`, `gd`, `gl`, `gp`. See that file for the full list.
+
+---
+
+## Global ignore
+
+`~/.gitignore_global` covers OS + editor cruft only — **not** `.env` / `.idea/` / `.vscode/`, which are per-project decisions:
+
+- macOS Finder metadata: `.DS_Store`, `.AppleDouble`, `.LSOverride`
+- Editor swap / temp: `.*.swp`, `.*.swo`, `*~`
+- Local-only env overrides: `.env.local`, `.envrc.local` (project-level `.env` / `.env.example` stay tracked)
+
+---
+
+## Change / Add a setting
+
+1. Edit `dot_gitconfig.tmpl` (or `dot_gitignore_global`).
+2. `chezmoi diff` — review the rendered diff against `~/.gitconfig`.
+3. `chezmoi apply`.
+4. Add a regression guard in `tests/git.sh` under **Active global config** if it's a knob we care about keeping.
+
+---
+
+## Health check
+
+### Automated
+
+```bash
+bash tests/git.sh
+```
+
+Covers: binary presence, target-file presence, every pinned setting under `[core] [init] [push] [fetch] [rebase] [merge] [interactive] [delta] [commit] [credential] [alias]`, and a template-side regression guard that both identity branches exist.
+
+### Manual
+
+- [ ] `git config --global user.email` matches the current machine's identity
+- [ ] `git diff <some-file-with-changes>` renders through delta (side-by-side, line numbers visible)
+- [ ] `git lg -5` shows a colored graph
+- [ ] Cloning a fresh HTTPS repo prompts for credentials once, then caches via Keychain
+- [ ] On the **other** machine after `chezmoi apply`: `user.email` is the other identity
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `fatal: bad config line N in file ~/.gitconfig` | Template failed to render cleanly | `chezmoi diff` / `chezmoi execute-template < dot_gitconfig.tmpl` to reproduce |
+| Identity is wrong after switching machines | `is_work` wasn't re-prompted | Edit `~/.config/chezmoi/chezmoi.toml` (flip `is_work`) → `chezmoi apply` |
+| `fatal: unknown style 'zdiff3'` | git < 2.35 | `brew upgrade git` |
+| Delta not invoked on `git diff` | `delta` missing from PATH | `brew install git-delta` |
+| `interactive.diffFilter` noise when stdin is not a tty | Expected: it only triggers interactively | Not a bug |
+
+---
+
+## Gotchas
+
+- **Scripts that parse `git diff` output** must pass `-c core.pager=cat` — otherwise delta's colored, paginated output confuses them.
+- **No global `.idea/` / `.vscode/` ignore** — these are per-project decisions. Add to repo-local `.gitignore` when relevant.
+- **`gh` credential helper** shadows `osxkeychain` for GitHub URLs after `gh auth login`. This is intentional; removing one doesn't break the other.
+- **Repo-local overrides take precedence.** `~/.dotfiles/.git/config` currently pins `user.email = yuzhezhong0117@qq.com` (legacy; safe to delete after Phase 6a merges and personal identity goes global-default on the personal Mac).
+
+---
+
+## Rebuild from scratch
+
+If `~/.gitconfig` / `~/.gitignore_global` get clobbered:
+
+```bash
+chezmoi apply ~/.gitconfig ~/.gitignore_global
+```
+
+No reinstall needed — chezmoi re-renders the template against current `is_work`.

--- a/docs/git.zh.md
+++ b/docs/git.zh.md
@@ -1,0 +1,121 @@
+# Git
+
+极简全局 git 配置 + 短短一份全局 ignore。身份按 `is_work` chezmoi prompt 切机器 —— 不用 `includeIf`，不按目录切。
+
+---
+
+## 工作方式
+
+| Source（repo） | Target（`$HOME`） | 行为 |
+|---|---|---|
+| `dot_gitconfig.tmpl` | `~/.gitconfig` | 身份由 `is_work` 切；共享项（delta、rebase、conflict style…）所有机器一致 |
+| `dot_gitignore_global` | `~/.gitignore_global` | 通过 `core.excludesFile` 引用 |
+
+chezmoi 在每次 `chezmoi apply` 时渲染模板 —— 不需要 hook 脚本。
+
+---
+
+## 为什么这么选
+
+1. **身份按机器切，不按目录切。** 历史 plan 里写过 `includeIf "gitdir:~/personal/"`；后来删掉，因为用户的实际习惯是"人在哪台 Mac 上就用哪台的身份"。同一个 repo 在两台 Mac 上 clone 会自动用不同身份 author。
+2. **`delta` 作为 pager + `interactive.diffFilter`。** 双栏、行号、n/N hunk 导航 —— Phase 2 Brewfile 里装的 `git-delta`。在脚本里需要覆盖成 `-c core.pager=cat`。
+3. **`merge.conflictstyle = zdiff3`。** 冲突标记里显示公共祖先 —— 比默认 `merge` 风格好解得多。要求 git ≥ 2.35（Brewfile 拉最新）。
+4. **`rebase.autoStash = true`。** 工作区脏时 `git pull --rebase` 自动 stash 而不是报错，免去每次手动 `git stash` / `git stash pop`。
+5. **不钉 `pull.rebase`。** zsh `OMZP::git` plugin 提供了 `gl`/`gp`；pull 策略留给各 repo 自己决定。Git 默认（merge）保留。
+6. **Alias 极简。** `OMZP::git` 已经提供 `gst` / `gco` / `gcb` / … —— `~/.gitconfig` 里只留 `lg`（因为这个命令长到 shell alias 不好写）。
+7. **`credential.helper = osxkeychain`。** macOS Keychain 存 HTTPS 凭据。GitHub 上 `gh auth login` 会装自己的 helper 顶在前面 —— 两个共存不冲突。
+
+---
+
+## 机器与身份对应
+
+| 机器 | `is_work` | `user.name` | `user.email` |
+|---|---|---|---|
+| 公司 Mac | `true` | `zyz` | `zhongyuzhe@bytedance.com` |
+| 个人 Mac | `false` | `Kyrie` | `yuzhezhong0117@qq.com` |
+
+值写在 `dot_gitconfig.tmpl` 里，`{{ if .is_work }} … {{ else }} … {{ end }}` 守护。`is_work` 在 `chezmoi init` 时询问一次，存到 `~/.config/chezmoi/chezmoi.toml`。要切的话 —— 重跑 `chezmoi init`，或者直接改 toml + `chezmoi apply`。
+
+---
+
+## Alias 清单
+
+`~/.gitconfig` 里的 git alias：
+
+| Alias | 展开为 |
+|---|---|
+| `git lg` | `log --graph --pretty=format:'%C(auto)%h%d %s %C(blue)(%cr) %C(bold blue)<%an>' --abbrev-commit` |
+
+shell 层的 git alias 在 `dot_config/zsh/aliases.zsh`（Phase 3）：`gst`、`gco`、`gcb`、`gcm`、`ga`、`gaa`、`gd`、`gl`、`gp`。完整列表见那个文件。
+
+---
+
+## 全局 ignore
+
+`~/.gitignore_global` 只盖 OS + 编辑器临时文件 —— **不包括** `.env` / `.idea/` / `.vscode/`，这些是 per-project 决策：
+
+- macOS Finder 元数据：`.DS_Store`、`.AppleDouble`、`.LSOverride`
+- 编辑器 swap / 临时：`.*.swp`、`.*.swo`、`*~`
+- 本地 env 覆盖：`.env.local`、`.envrc.local`（项目级 `.env` / `.env.example` 仍跟踪）
+
+---
+
+## 改 / 加一项设置
+
+1. 改 `dot_gitconfig.tmpl`（或 `dot_gitignore_global`）。
+2. `chezmoi diff` —— 对比 `~/.gitconfig` 看渲染后的 diff。
+3. `chezmoi apply`。
+4. 如果这项值得长期钉住，在 `tests/git.sh` **Active global config** 段加一条 regression guard。
+
+---
+
+## 健康检查
+
+### 自动
+
+```bash
+bash tests/git.sh
+```
+
+覆盖：二进制存在、目标文件存在、每个钉住的 `[core] [init] [push] [fetch] [rebase] [merge] [interactive] [delta] [commit] [credential] [alias]` 设置、以及模板里两份身份都存在的 regression guard。
+
+### 手动
+
+- [ ] `git config --global user.email` 跟当前机器身份一致
+- [ ] `git diff <有改动的文件>` 经 delta 渲染（双栏、行号可见）
+- [ ] `git lg -5` 出彩色 graph
+- [ ] 全新 HTTPS repo clone 第一次问凭据，之后走 Keychain 缓存
+- [ ] 在**另一台** Mac 上 `chezmoi apply` 后，`user.email` 是另一个身份
+
+---
+
+## 疑难排查
+
+| 现象 | 可能原因 | 修法 |
+|---|---|---|
+| `fatal: bad config line N in file ~/.gitconfig` | 模板没渲好 | `chezmoi diff` / `chezmoi execute-template < dot_gitconfig.tmpl` 复现 |
+| 切机器后身份错 | `is_work` 没重问 | 改 `~/.config/chezmoi/chezmoi.toml` 里的 `is_work` → `chezmoi apply` |
+| `fatal: unknown style 'zdiff3'` | git < 2.35 | `brew upgrade git` |
+| `git diff` 没走 delta | PATH 里没 `delta` | `brew install git-delta` |
+| 非 tty 输出夹杂 `interactive.diffFilter` 噪声 | 预期：只在交互式触发 | 不是 bug |
+
+---
+
+## 注意
+
+- **解析 `git diff` 输出的脚本**必须带 `-c core.pager=cat` —— 不然 delta 的彩色分页会搞坏解析。
+- **没有全局 `.idea/` / `.vscode/` ignore** —— 这是 per-project 决策，需要的话加到 repo 本地 `.gitignore`。
+- **`gh` credential helper** 在 `gh auth login` 之后会顶在 `osxkeychain` 之前处理 GitHub URL。这是故意的；删一个不影响另一个。
+- **repo 本地 override 优先。** `~/.dotfiles/.git/config` 目前钉着 `user.email = yuzhezhong0117@qq.com`（历史遗留；Phase 6a 合并后、个人 Mac 上 global 默认切到 personal 之后，可以删掉）。
+
+---
+
+## 从零重建
+
+如果 `~/.gitconfig` / `~/.gitignore_global` 被覆盖：
+
+```bash
+chezmoi apply ~/.gitconfig ~/.gitignore_global
+```
+
+不用重装 —— chezmoi 根据当前 `is_work` 重新渲染模板。

--- a/docs/git.zh.md
+++ b/docs/git.zh.md
@@ -1,6 +1,6 @@
-# Git
+# Git 及配套工具
 
-极简全局 git 配置 + 短短一份全局 ignore。身份按 `is_work` chezmoi prompt 切机器 —— 不用 `includeIf`，不按目录切。
+极简全局 git 配置 + 全局 ignore，外加 `lazygit`（TUI）和 `gh`（CLI）。身份按 `is_work` chezmoi prompt 切机器 —— 不用 `includeIf`，不按目录切。
 
 ---
 
@@ -10,8 +10,12 @@
 |---|---|---|
 | `dot_gitconfig.tmpl` | `~/.gitconfig` | 身份由 `is_work` 切；共享项（delta、rebase、conflict style…）所有机器一致 |
 | `dot_gitignore_global` | `~/.gitignore_global` | 通过 `core.excludesFile` 引用 |
+| `dot_config/lazygit/config.yml` | `~/.config/lazygit/config.yml` | Catppuccin Mocha 主题 + delta pager + nvim edit |
+| `dot_config/gh/config.yml` | `~/.config/gh/config.yml` | PR 高频 alias（`pv`、`pl`、`pc`、`pm`…） |
 
 chezmoi 在每次 `chezmoi apply` 时渲染模板 —— 不需要 hook 脚本。
+
+> **关于 lazygit 的 config 路径。** macOS 下 lazygit 默认读 `~/Library/Application Support/lazygit/`。我们在 `dot_zshenv` 里 `export XDG_CONFIG_HOME="$HOME/.config"`，让 lazygit（以及所有 XDG-aware 工具）改读 `~/.config/` —— 跟 Linux 一致。验证：`lazygit --print-config-dir` 应返回 `~/.config/lazygit`。
 
 ---
 
@@ -60,6 +64,39 @@ shell 层的 git alias 在 `dot_config/zsh/aliases.zsh`（Phase 3）：`gst`、`
 
 ---
 
+## lazygit
+
+Kickstart 风格 80%-够用配置 —— 按实际需求再定制化。
+
+- **主题：** Catppuccin Mocha，跟 ghostty / yazi / starship 同色板（`#89b4fa` 蓝色活动边框、`#313244` 选中背景…）
+- **Pager：** `delta --paging=never`，让 lazygit diff pane 跟 `git diff` 输出一致
+- **编辑器：** `nvim` 经 `os.edit` / `os.editAtLine` —— staging pane 上按 `e` 打开文件时会跳到正确行
+- **其他：** 文件树开、随机 tip 关、mouse events 开、nerd fonts v3
+
+运行时注意：lazygit **不读** `~/.gitconfig` 的 `[alias]` —— TUI 由 lazygit 自己的 keymap 驱动。shell 用的 git alias 照常留在 `~/.gitconfig`。
+
+---
+
+## gh（GitHub CLI）
+
+`config.yml` 只写非默认值；没列的 key 用 gh 内置默认。用 `gh config list` 核对。
+
+为 PR review 流程优化的 alias：
+
+| Alias | 展开 | 用途 |
+|---|---|---|
+| `gh co` | `pr checkout` | 把 PR 拉下来本地测 |
+| `gh pv` | `pr view` | 终端读 PR body + 评论（`-w` 开浏览器） |
+| `gh pl` | `pr list` | 看未合并 PR |
+| `gh pc` | `pr checks` | 当前分支 PR 的 CI 状态 |
+| `gh pm` | `pr merge` | 合（按 repo 策略加 `--squash` / `--rebase`） |
+| `gh prs` | `pr status` | 跟自己有关的 PR（author / assignee / review-requested） |
+| `gh il` / `gh iv` | `issue list` / `issue view` | Issue 版本 |
+
+> **`hosts.yml` 不跟踪。** 那里放 per-machine 认证状态（用户名 + keyring 路径；oauth_token 本身在 macOS Keychain 里）。`.chezmoiignore` 预防性地排掉 `dot_config/gh/hosts.yml`，防它万一漏进 source。
+
+---
+
 ## 改 / 加一项设置
 
 1. 改 `dot_gitconfig.tmpl`（或 `dot_gitignore_global`）。
@@ -85,6 +122,9 @@ bash tests/git.sh
 - [ ] `git diff <有改动的文件>` 经 delta 渲染（双栏、行号可见）
 - [ ] `git lg -5` 出彩色 graph
 - [ ] 全新 HTTPS repo clone 第一次问凭据，之后走 Keychain 缓存
+- [ ] `lazygit --print-config-dir` 返回 `~/.config/lazygit`（不是 `~/Library/…`）
+- [ ] `lazygit` 打开后是 Mocha 蓝色边框 + delta 渲染的 diff
+- [ ] `gh pv` / `gh pc` 在任意目录里针对当前 repo 的 PR 起效
 - [ ] 在**另一台** Mac 上 `chezmoi apply` 后，`user.email` 是另一个身份
 
 ---
@@ -98,6 +138,8 @@ bash tests/git.sh
 | `fatal: unknown style 'zdiff3'` | git < 2.35 | `brew upgrade git` |
 | `git diff` 没走 delta | PATH 里没 `delta` | `brew install git-delta` |
 | 非 tty 输出夹杂 `interactive.diffFilter` 噪声 | 预期：只在交互式触发 | 不是 bug |
+| lazygit 忽略 `~/.config/lazygit/config.yml` | 当前 shell 没 export `XDG_CONFIG_HOME` | 开新 zsh（会读 `dot_zshenv`），或手动 `export XDG_CONFIG_HOME=$HOME/.config` |
+| `gh` 在已登录过的机器上又问登录 | `hosts.yml` 没了（本来就不跟踪） | `gh auth login` —— 每台机器做一次 |
 
 ---
 

--- a/dot_config/gh/config.yml
+++ b/dot_config/gh/config.yml
@@ -1,0 +1,17 @@
+# gh CLI config — aliases optimized for PR-heavy workflows (reviewing,
+# merging, checking CI). Only non-default values are listed; unset keys
+# fall back to gh's built-in defaults (run `gh config list` to confirm).
+# hosts.yml holds per-machine auth state and is NEVER tracked.
+
+version: 1
+git_protocol: https
+
+aliases:
+    co: pr checkout      # check out a PR locally
+    pv: pr view          # view PR in terminal (use -w for browser)
+    pl: pr list
+    pc: pr checks        # CI status for current branch's PR
+    pm: pr merge
+    prs: pr status       # PRs involving you
+    il: issue list
+    iv: issue view

--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -1,0 +1,44 @@
+# lazygit — general-purpose kickstart config.
+# Theme: Catppuccin Mocha (matches ghostty / yazi / starship palette).
+# Only 80%-useful knobs; customize later as needs emerge.
+# Schema ref: https://github.com/jesseduffield/lazygit/blob/master/docs/Config.md
+
+gui:
+  # Catppuccin Mocha — same palette as the other Phase-4 UIs.
+  theme:
+    activeBorderColor:
+      - "#89b4fa"   # blue
+      - bold
+    inactiveBorderColor:
+      - "#a6adc8"   # subtext0
+    optionsTextColor:
+      - "#89b4fa"
+    selectedLineBgColor:
+      - "#313244"   # surface0
+    cherryPickedCommitBgColor:
+      - "#94e2d5"   # teal
+    cherryPickedCommitFgColor:
+      - "#89b4fa"
+    unstagedChangesColor:
+      - "#f38ba8"   # red
+    defaultFgColor:
+      - "#cdd6f4"   # text
+    searchingActiveBorderColor:
+      - "#f9e2af"   # yellow
+  showFileTree: true
+  showRandomTip: false
+  showBottomLine: false
+  nerdFontsVersion: "3"
+  mouseEvents: true
+
+git:
+  # Route diffs through delta so lazygit's diff pane matches `git diff`.
+  paging:
+    colorArg: always
+    pager: delta --paging=never
+  autoFetch: true
+  autoRefresh: true
+
+os:
+  edit: 'nvim {{filename}}'
+  editAtLine: 'nvim +{{line}} {{filename}}'

--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -33,9 +33,11 @@ gui:
 
 git:
   # Route diffs through delta so lazygit's diff pane matches `git diff`.
-  paging:
-    colorArg: always
-    pager: delta --paging=never
+  # Schema: lazygit ≥ 0.40 replaced `git.paging` (object) with `git.pagers`
+  # (array). Each entry is a pager candidate; single unnamed entry = default.
+  pagers:
+    - colorArg: always
+      pager: delta --paging=never
   autoFetch: true
   autoRefresh: true
 

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,0 +1,46 @@
+{{/* Identity per machine — see docs/git.md "Identity per machine". */}}
+[user]
+{{- if .is_work }}
+	name  = zyz
+	email = zhongyuzhe@bytedance.com
+{{- else }}
+	name  = Kyrie
+	email = yuzhezhong0117@qq.com
+{{- end }}
+
+[core]
+	editor       = nvim
+	pager        = delta
+	excludesFile = ~/.gitignore_global
+
+[init]
+	defaultBranch = main
+
+[push]
+	autoSetupRemote = true
+
+[fetch]
+	prune = true
+
+[rebase]
+	autoStash = true
+
+[merge]
+	conflictstyle = zdiff3
+
+[interactive]
+	diffFilter = delta --color-only
+
+[delta]
+	navigate     = true
+	side-by-side = true
+	line-numbers = true
+
+[commit]
+	verbose = true
+
+[credential]
+	helper = osxkeychain
+
+[alias]
+	lg = log --graph --pretty=format:'%C(auto)%h%d %s %C(blue)(%cr) %C(bold blue)<%an>' --abbrev-commit

--- a/dot_gitignore_global
+++ b/dot_gitignore_global
@@ -1,0 +1,13 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Editor swap / temp
+.*.swp
+.*.swo
+*~
+
+# Local-only env overrides (keep .env/.env.example tracked per-project)
+.env.local
+.envrc.local

--- a/dot_zshenv
+++ b/dot_zshenv
@@ -8,3 +8,9 @@ export PATH="$HOME/.local/bin:$PATH"
 export EDITOR="nvim"
 export VISUAL="$EDITOR"
 export LANG="en_US.UTF-8"
+
+# XDG base — makes macOS-native apps (lazygit, …) read ~/.config/ too,
+# so every tool's config lives in one place instead of splitting between
+# ~/.config/ and ~/Library/Application Support/. Data/cache keep their
+# defaults (tools already use XDG fallback for those where relevant).
+export XDG_CONFIG_HOME="$HOME/.config"

--- a/tests/git.sh
+++ b/tests/git.sh
@@ -17,10 +17,10 @@ check() {
     if out=$(eval "$cmd" 2>&1); then ok "$name"; else bad "$name" "$out"; fi
 }
 
-SRC="/Users/bytedance/.dotfiles/dot_gitconfig.tmpl"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$REPO_ROOT/dot_gitconfig.tmpl"
 GC="$HOME/.gitconfig"
 GI="$HOME/.gitignore_global"
-
 LG="$HOME/.config/lazygit/config.yml"
 GHCFG="$HOME/.config/gh/config.yml"
 
@@ -71,30 +71,31 @@ echo
 echo "── lazygit config ───────────────────────────────────"
 # XDG_CONFIG_HOME must be set in zshenv, else lazygit reads
 # ~/Library/Application Support/lazygit/ on macOS and our config is dead.
-check "XDG_CONFIG_HOME set in dot_zshenv"       "grep -q 'export XDG_CONFIG_HOME=\"\$HOME/.config\"' /Users/bytedance/.dotfiles/dot_zshenv"
-check "lazygit config.yml parses (yaml)"        "python3 -c 'import yaml,sys; yaml.safe_load(open(\"$LG\"))'"
+check "XDG_CONFIG_HOME set in dot_zshenv"       "grep -q 'export XDG_CONFIG_HOME=\"\$HOME/.config\"' $REPO_ROOT/dot_zshenv"
+# YAML syntax is pre-validated by pre-commit `check-yaml` (commit-time
+# gate); here we only spot-check semantics that grep can verify.
 check "lazygit theme = catppuccin mocha blue"   "grep -q '#89b4fa' $LG"
 check "lazygit uses delta pager"                "grep -q 'pager: delta' $LG"
 check "lazygit edit = nvim"                     "grep -q \"edit: 'nvim {{filename}}'\" $LG"
 
 echo
 echo "── gh config ────────────────────────────────────────"
-check "gh config.yml parses (yaml)"             "python3 -c 'import yaml,sys; yaml.safe_load(open(\"$GHCFG\"))'"
 check "gh git_protocol = https"                 "grep -q 'git_protocol: https' $GHCFG"
 check "gh alias 'co' (pr checkout)"             "grep -q 'co: pr checkout' $GHCFG"
 check "gh alias 'pv' (pr view)"                 "grep -q 'pv: pr view' $GHCFG"
 check "gh alias 'pc' (pr checks)"               "grep -q 'pc: pr checks' $GHCFG"
-# Cross-check: gh actually parses the aliases (not just YAML-valid but
-# gh-valid). `gh alias list` exits non-zero if the file is corrupt.
+# `gh alias list` parses the entire config through gh's own schema —
+# catches structural breakage that grep would miss and obsoletes a
+# generic YAML parse check.
 check "gh alias list succeeds"                  "gh alias list >/dev/null"
-check "hosts.yml ignored in chezmoi source"     "grep -q 'dot_config/gh/hosts.yml' /Users/bytedance/.dotfiles/.chezmoiignore"
+check "hosts.yml ignored in chezmoi source"     "grep -q 'dot_config/gh/hosts.yml' $REPO_ROOT/.chezmoiignore"
 
 echo
 echo "── Smoke ────────────────────────────────────────────"
 # Active identity matches the active machine's is_work — we're always on
 # one or the other, so whichever renders must be self-consistent.
 check "active identity matches template"        "git config --global user.email | grep -qE '^(zhongyuzhe@bytedance\.com|yuzhezhong0117@qq\.com)$'"
-check "git lg alias renders (cat pager)"        "git -C /Users/bytedance/.dotfiles -c core.pager=cat lg -1 >/dev/null"
+check "git lg alias renders (cat pager)"        "git -C $REPO_ROOT -c core.pager=cat lg -1 >/dev/null"
 
 echo
 if [ $FAIL -eq 0 ]; then

--- a/tests/git.sh
+++ b/tests/git.sh
@@ -21,14 +21,21 @@ SRC="/Users/bytedance/.dotfiles/dot_gitconfig.tmpl"
 GC="$HOME/.gitconfig"
 GI="$HOME/.gitignore_global"
 
+LG="$HOME/.config/lazygit/config.yml"
+GHCFG="$HOME/.config/gh/config.yml"
+
 echo "── Binary ───────────────────────────────────────────"
 check "git on PATH"                             "command -v git >/dev/null"
 check "delta on PATH"                           "command -v delta >/dev/null"
+check "lazygit on PATH"                         "command -v lazygit >/dev/null"
+check "gh on PATH"                              "command -v gh >/dev/null"
 
 echo
 echo "── Target files present ─────────────────────────────"
 check "~/.gitconfig present"                    "test -r $GC"
 check "~/.gitignore_global present"             "test -r $GI"
+check "~/.config/lazygit/config.yml present"    "test -r $LG"
+check "~/.config/gh/config.yml present"         "test -r $GHCFG"
 
 echo
 echo "── Active global config ─────────────────────────────"
@@ -59,6 +66,28 @@ check "work name (zyz) in template"             "grep -q 'name  = zyz' $SRC"
 check "work email (bytedance) in template"      "grep -q 'email = zhongyuzhe@bytedance.com' $SRC"
 check "personal name (Kyrie) in template"       "grep -q 'name  = Kyrie' $SRC"
 check "personal email (qq) in template"         "grep -q 'email = yuzhezhong0117@qq.com' $SRC"
+
+echo
+echo "── lazygit config ───────────────────────────────────"
+# XDG_CONFIG_HOME must be set in zshenv, else lazygit reads
+# ~/Library/Application Support/lazygit/ on macOS and our config is dead.
+check "XDG_CONFIG_HOME set in dot_zshenv"       "grep -q 'export XDG_CONFIG_HOME=\"\$HOME/.config\"' /Users/bytedance/.dotfiles/dot_zshenv"
+check "lazygit config.yml parses (yaml)"        "python3 -c 'import yaml,sys; yaml.safe_load(open(\"$LG\"))'"
+check "lazygit theme = catppuccin mocha blue"   "grep -q '#89b4fa' $LG"
+check "lazygit uses delta pager"                "grep -q 'pager: delta' $LG"
+check "lazygit edit = nvim"                     "grep -q \"edit: 'nvim {{filename}}'\" $LG"
+
+echo
+echo "── gh config ────────────────────────────────────────"
+check "gh config.yml parses (yaml)"             "python3 -c 'import yaml,sys; yaml.safe_load(open(\"$GHCFG\"))'"
+check "gh git_protocol = https"                 "grep -q 'git_protocol: https' $GHCFG"
+check "gh alias 'co' (pr checkout)"             "grep -q 'co: pr checkout' $GHCFG"
+check "gh alias 'pv' (pr view)"                 "grep -q 'pv: pr view' $GHCFG"
+check "gh alias 'pc' (pr checks)"               "grep -q 'pc: pr checks' $GHCFG"
+# Cross-check: gh actually parses the aliases (not just YAML-valid but
+# gh-valid). `gh alias list` exits non-zero if the file is corrupt.
+check "gh alias list succeeds"                  "gh alias list >/dev/null"
+check "hosts.yml ignored in chezmoi source"     "grep -q 'dot_config/gh/hosts.yml' /Users/bytedance/.dotfiles/.chezmoiignore"
 
 echo
 echo "── Smoke ────────────────────────────────────────────"

--- a/tests/git.sh
+++ b/tests/git.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Non-interactive git config health check. ~1s. Covers binary presence,
+# target-file presence, and a regression guard on every setting we
+# intentionally pin in dot_gitconfig.tmpl. Identity-per-machine is verified
+# by grepping the source template (both branches must be present); the
+# currently-active identity is verified via `git config --global`. Manual
+# cross-machine check is in docs/git.md → Health check → Manual.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$1"; PASS=$((PASS+1)); }
+bad() { printf "  \033[31m✗\033[0m %s\n" "$1"; [[ -n ${2:-} ]] && printf "    %s\n" "$2"; FAIL=$((FAIL+1)); }
+
+check() {
+    local name=$1 cmd=$2 out
+    if out=$(eval "$cmd" 2>&1); then ok "$name"; else bad "$name" "$out"; fi
+}
+
+SRC="/Users/bytedance/.dotfiles/dot_gitconfig.tmpl"
+GC="$HOME/.gitconfig"
+GI="$HOME/.gitignore_global"
+
+echo "── Binary ───────────────────────────────────────────"
+check "git on PATH"                             "command -v git >/dev/null"
+check "delta on PATH"                           "command -v delta >/dev/null"
+
+echo
+echo "── Target files present ─────────────────────────────"
+check "~/.gitconfig present"                    "test -r $GC"
+check "~/.gitignore_global present"             "test -r $GI"
+
+echo
+echo "── Active global config ─────────────────────────────"
+check "user.name set"                           "test -n \"$(git config --global user.name)\""
+check "user.email set"                          "test -n \"$(git config --global user.email)\""
+check "core.editor = nvim"                      "test \"$(git config --global core.editor)\" = nvim"
+check "core.pager = delta"                      "test \"$(git config --global core.pager)\" = delta"
+check "core.excludesFile = ~/.gitignore_global" "test \"\$(git config --global core.excludesFile)\" = '~/.gitignore_global'"
+check "init.defaultBranch = main"               "test \"$(git config --global init.defaultBranch)\" = main"
+check "push.autoSetupRemote = true"             "test \"$(git config --global push.autoSetupRemote)\" = true"
+check "fetch.prune = true"                      "test \"$(git config --global fetch.prune)\" = true"
+check "rebase.autoStash = true"                 "test \"$(git config --global rebase.autoStash)\" = true"
+check "merge.conflictstyle = zdiff3"            "test \"$(git config --global merge.conflictstyle)\" = zdiff3"
+check "interactive.diffFilter uses delta"       "git config --global interactive.diffFilter | grep -q '^delta'"
+check "delta.navigate = true"                   "test \"$(git config --global delta.navigate)\" = true"
+check "delta.side-by-side = true"               "test \"$(git config --global delta.side-by-side)\" = true"
+check "delta.line-numbers = true"               "test \"$(git config --global delta.line-numbers)\" = true"
+check "commit.verbose = true"                   "test \"$(git config --global commit.verbose)\" = true"
+check "credential.helper = osxkeychain"         "test \"$(git config --global credential.helper)\" = osxkeychain"
+check "alias.lg set"                            "test -n \"$(git config --global alias.lg)\""
+
+echo
+echo "── Identity per is_work (template both branches) ────"
+# Non-interactive check: both identities must be present in source, and
+# must be guarded by is_work so the render picks exactly one.
+check "template branches on is_work"            "grep -q '{{- if .is_work }}' $SRC"
+check "work name (zyz) in template"             "grep -q 'name  = zyz' $SRC"
+check "work email (bytedance) in template"      "grep -q 'email = zhongyuzhe@bytedance.com' $SRC"
+check "personal name (Kyrie) in template"       "grep -q 'name  = Kyrie' $SRC"
+check "personal email (qq) in template"         "grep -q 'email = yuzhezhong0117@qq.com' $SRC"
+
+echo
+echo "── Smoke ────────────────────────────────────────────"
+# Active identity matches the active machine's is_work — we're always on
+# one or the other, so whichever renders must be self-consistent.
+check "active identity matches template"        "git config --global user.email | grep -qE '^(zhongyuzhe@bytedance\.com|yuzhezhong0117@qq\.com)$'"
+check "git lg alias renders (cat pager)"        "git -C /Users/bytedance/.dotfiles -c core.pager=cat lg -1 >/dev/null"
+
+echo
+if [ $FAIL -eq 0 ]; then
+    printf "\n  \033[32m%d passed, 0 failed\033[0m\n" $PASS
+    exit 0
+else
+    printf "\n  \033[31m%d passed, %d failed\033[0m\n" $PASS $FAIL
+    exit 1
+fi


### PR DESCRIPTION
## Summary / 概述

Phase 6a — minimal global git config (identity switched per-machine via `is_work`, not per-directory), plus the companion tools users actually drive from the CLI/TUI: `lazygit` (Catppuccin Mocha + delta pager) and `gh` (PR-review aliases). Sets `XDG_CONFIG_HOME=$HOME/.config` in `dot_zshenv` so lazygit reads the same path on macOS as on Linux.

## Change type / 变更类型

- [x] `feat` — new package / functionality · 新包或新功能
- [ ] `fix` — bug fix · bug 修复
- [ ] `chore` — infrastructure, hooks, dependency bumps · 基础设施 / hooks / 依赖升级
- [ ] `docs` — documentation only · 纯文档
- [ ] `refactor` — no behavior change · 纯重构（无行为变化）

## Checklist / 检查清单

- [x] Commit messages follow Conventional Commits · Commit 信息符合 Conventional Commits
- [x] `pre-commit run --all-files` passes locally · 本地跑过 `pre-commit run --all-files` 且全绿
- [x] `chezmoi diff` reviewed; no surprising deletions or permission changes · 已 review `chezmoi diff`，没有意外的删除或权限变化
- [ ] New package → entry added to the `Layout` section of `README.md` · 新包已加入 `README.md` 的 `Layout` 小节
  - README `Layout` uses abstract `dot_*` / `*.tmpl` placeholders, not per-package lines — no drift. · README Layout 用的是抽象 `dot_*` / `*.tmpl`，不是逐包列，没 drift。
- [x] New CLI tool → added to `Brewfile` · 新 CLI 工具已加入 `Brewfile`
  - `git-delta`, `lazygit`, `gh` already shipped in Phase 2 Brewfile. · `git-delta`、`lazygit`、`gh` Phase 2 Brewfile 已经带了。
- [x] Smoke-tested end-to-end on at least one Mac · 在至少一台 Mac 上做过端到端冒烟
  - `tests/git.sh` 44/44 green; `lazygit --print-config-dir` = `~/.config/lazygit`; `gh alias list` lists all 8 aliases; new shell reads `XDG_CONFIG_HOME`.

## Notes for reviewer / 给 reviewer 的说明

**Identity strategy simplification.** Original plan had per-directory `includeIf` splitting (`config.personal` / `config.work`). Dropped in favor of `{{ if .is_work }}` in `dot_gitconfig.tmpl` — user's actual habit is "whichever Mac I'm on, commit as that Mac"; projects mix freely, no directory-based identity needed. Saved memory: `project_git_identity.md`.

**`XDG_CONFIG_HOME` is a global env-var change in `dot_zshenv`.** Blast radius audit: every user-facing tool we track (starship, ghostty, yazi, fastfetch, zsh, karabiner) already stores config under `~/.config/`, so their paths don't shift. The visible effect is that lazygit — which on macOS defaults to `~/Library/Application Support/lazygit/` — now reads `~/.config/lazygit/`. Any third-party tool that was previously using a macOS-native config path and becomes XDG-aware will also move; user has no such tools currently tracked.

**lazygit schema fix (commit 3).** lazygit ≥ 0.40 auto-migrated `git.paging` → `git.pagers` on first launch (user flagged the "Moved git.paging object to git.pagers array" message). Source was then out of sync → next `chezmoi apply` would write old schema back → migration loop. `b3e7177` syncs source to the new schema so it closes.

**`hosts.yml` is pre-emptively ignored in `.chezmoiignore`**. It holds per-machine auth state (oauth_token itself is in macOS Keychain on recent gh, but the file references the keyring slot). Never tracked; each machine does `gh auth login` once.

**Phase 8/9 dropped from plan.** Pre-commit base (whitespace / gitleaks / conventional-commits) was done in Phase 0; `.github/` templates done in batch post-processing; remaining Phase-8 ideas (`ruff`, `validate-pyproject`) have no Python in this repo. Phase 9 cross-machine smoke is user-owned (no memory value). Plan file updated.

**Phase 6b (Claude config) lands in a follow-up PR**, not bundled here, per user request to split.

---

_Generated with Claude Code._