### PR TITLE
fix(brewfile): add node runtime for Claude plugin hooks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -44,6 +44,13 @@ brew "sevenzip"
 # ---- Python ----------------------------------------------------------------
 brew "uv"
 
+# ---- Node.js ---------------------------------------------------------------
+# Required by Claude Code plugins that ship .mjs hooks (e.g. openai-codex's
+# SessionStart/SessionEnd/Stop lifecycle hooks) and by the PreToolUse guard
+# `npx block-no-verify@1.1.2`. `bun` is not a drop-in replacement here — the
+# hooks rely on Node's native ESM/stream semantics.
+brew "node"
+
 # ---- Mac App Store CLI -----------------------------------------------------
 brew "mas"
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The core tools this repo leans on.
 | [age](https://github.com/FiloSottile/age) | secret encryption | bootstrap → `brew install age` |
 | [gh](https://cli.github.com) | GitHub CLI (PR / review flow) | bootstrap → `brew install gh` |
 | [Claude Code](https://claude.com/claude-code) | AI coding CLI | bootstrap → `curl -fsSL https://claude.ai/install.sh \| bash` |
+| [Node.js](https://nodejs.org) | Runtime for Claude Code plugin hooks (`.mjs`) and `npx`-based guards | Brewfile → `brew install node` |
 | [uv](https://github.com/astral-sh/uv) | Python tool runner | Brewfile → `brew install uv` |
 | [pre-commit](https://pre-commit.com) | Git hooks (whitespace / secrets / conventional-commits) | `uv tool install pre-commit` — setup in [CONTRIBUTING.md](CONTRIBUTING.md) |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,6 +50,7 @@ repo 依赖的核心工具。
 | [age](https://github.com/FiloSottile/age) | 密文加密 | bootstrap → `brew install age` |
 | [gh](https://cli.github.com) | GitHub CLI（PR / review 流程必备） | bootstrap → `brew install gh` |
 | [Claude Code](https://claude.com/claude-code) | AI coding CLI | bootstrap → `curl -fsSL https://claude.ai/install.sh \| bash` |
+| [Node.js](https://nodejs.org) | Claude Code 插件 `.mjs` hook 与 `npx` 守卫的运行时 | Brewfile → `brew install node` |
 | [uv](https://github.com/astral-sh/uv) | Python 工具运行器 | Brewfile → `brew install uv` |
 | [pre-commit](https://pre-commit.com) | Git hooks（空白符/密钥/conventional-commits） | `uv tool install pre-commit` —— 流程见 [CONTRIBUTING.zh.md](CONTRIBUTING.zh.md) |
 


### PR DESCRIPTION
## Summary / 概述

Phase 2 Brewfile 从未登记 `node`，导致 `brew bundle cleanup` 后 Claude Code 插件的 `.mjs` hooks（openai-codex 的 SessionStart/SessionEnd/Stop）和 `npx block-no-verify` 全部报 `/bin/sh: node: command not found`。这个 PR 把 node 显式列进 Brewfile，并同步到 README toolchain 表，让依赖可见。

Phase 2 Brewfile never declared `node`; once `brew bundle cleanup` removed it, every Claude Code plugin `.mjs` hook (openai-codex lifecycle + `npx block-no-verify`) broke with "node: command not found". This PR makes the dependency explicit in Brewfile and surfaces it in the README toolchain table.

## Change type / 变更类型

- [x] `fix` — bug fix · bug 修复

## Checklist / 检查清单

- [x] Commit messages follow Conventional Commits · Commit 信息符合 Conventional Commits
- [x] `pre-commit run --all-files` passes locally · 本地跑过 `pre-commit run --all-files` 且全绿
- [x] `chezmoi diff` reviewed; no surprising deletions or permission changes · 已 review `chezmoi diff`，没有意外的删除或权限变化
- [x] New CLI tool → added to `Brewfile` · 新 CLI 工具已加入 `Brewfile`
- [x] Smoke-tested end-to-end on at least one Mac · 在至少一台 Mac 上做过端到端冒烟

## Notes for reviewer / 给 reviewer 的说明

- **Why node and not bun** — openai-codex hooks shell out to `node` explicitly in `hooks.json`; bun has edge-case incompatibilities in ESM/stream semantics and would be a silent source of future breakage. Comment in Brewfile records the reasoning.
- **Smoke test**:
  - `node --version` → `v25.9.0`; `npx --version` → `11.12.1`
  - `node ~/.claude/plugins/cache/openai-codex/codex/1.0.3/scripts/session-lifecycle-hook.mjs SessionStart </dev/null` → exit 0 (pre-fix: `command not found`)
  - `brew bundle check --verbose` → "The Brewfile's dependencies are satisfied."
- **No test script touched** — `tests/` has no `brew.sh` (Brewfile has never had its own smoke test; `brew bundle check` in CI / apply is the de-facto check). That's also why this regression slipped through previous phases.

_Generated with Claude Code._