### PR TITLE
feat(claude): version ~/.claude/settings.json + usage guide

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -15,3 +15,43 @@ tests
 # — oauth_token itself is in macOS Keychain, but don't risk it). Never
 # track; ignore pre-emptively in case the file lands in source.
 dot_config/gh/hosts.yml
+
+# Phase 6b: ~/.claude is a live runtime directory. Only settings.json is
+# source-managed (via dot_claude/settings.json). Everything else below
+# is per-machine state — sessions, caches, logs, auto-memory, plugin
+# install state, permission allowlists — and must never enter the repo.
+#
+# The pattern is: deny the whole tree, then stop (we simply don't `chezmoi
+# add` these). Listed defensively so an accidental `chezmoi add ~/.claude`
+# is a no-op for runtime paths.
+dot_claude/settings.local.json
+dot_claude/backups/**
+dot_claude/cache/**
+dot_claude/chrome/**
+dot_claude/downloads/**
+dot_claude/file-history/**
+dot_claude/homunculus/**
+dot_claude/image-cache/**
+dot_claude/metrics/**
+dot_claude/paste-cache/**
+dot_claude/plans/**
+dot_claude/plugins/**
+dot_claude/projects/**
+dot_claude/session-data/**
+dot_claude/session-env/**
+dot_claude/sessions/**
+dot_claude/shell-snapshots/**
+dot_claude/tasks/**
+dot_claude/telemetry/**
+dot_claude/*.jsonl
+dot_claude/*.log
+dot_claude/*-cache.json
+# Extension points we don't yet version (agents / skills / commands /
+# rules / user-level CLAUDE.md). Ignored pre-emptively so that if they
+# appear on disk they don't sneak into source on a stray `chezmoi add`.
+# Delete an entry here before opting a path into source control.
+dot_claude/agents/**
+dot_claude/skills/**
+dot_claude/commands/**
+dot_claude/rules/**
+dot_claude/CLAUDE.md

--- a/docs/claude.md
+++ b/docs/claude.md
@@ -1,0 +1,423 @@
+# Claude Code
+
+> English · [中文](claude.zh.md)
+
+Cross-machine Claude Code config: **`~/.claude/settings.json` only.** Everything else under `~/.claude/` — sessions, auto-memory, plugin caches, session-env, logs, allowlists — is machine-local runtime state and **ignored on purpose** (see `.chezmoiignore`).
+
+Phase 6c will tackle plugins / MCP / skills separately; this phase is just the settings spine.
+
+## How it works
+
+| Source (repo) | Target (`$HOME`) | Behavior |
+|---|---|---|
+| `dot_claude/settings.json` | `~/.claude/settings.json` | Plain copy. No template — every field is currently cross-machine. |
+| _(excluded)_ | `~/.claude/settings.local.json` | Per-project permission allowlist; machine-specific paths only. |
+| _(excluded)_ | `~/.claude/sessions/` `projects/` `plans/` `cache/` `…` | Runtime only — see **Runtime exclusions** below. |
+
+`chezmoi apply` renders `dot_claude/settings.json` to `~/.claude/settings.json`. No hook scripts, no plugin re-install — `enabledPlugins` declares intent, Claude's internal marketplace fetcher resolves it on next launch.
+
+## Two persistence systems (why we only manage one)
+
+Claude Code has **two** cross-session memory mechanisms. We only version the first:
+
+| | **Settings** (`settings.json`) | **Memory** (`CLAUDE.md` + auto-memory) |
+|---|---|---|
+| Writes | You, declarative JSON | You write `CLAUDE.md`; Claude writes auto-memory |
+| Strength | Hard — `deny` rules and hooks can block tool calls | Soft — context injected as a user message, no enforcement |
+| Cross-machine | Yes (when placed in repo) | **No — auto-memory is explicitly machine-local per [docs](https://code.claude.com/docs/en/memory#storage-location)** |
+| Our repo | `dot_claude/settings.json` | Deferred; no user-level `CLAUDE.md` tracked yet |
+
+The second system is worth knowing about but *must not* enter the repo: `~/.claude/projects/<proj>/memory/MEMORY.md` is a per-working-tree artifact that would leak between work and personal Macs if shared.
+
+## Pinned fields
+
+`dot_claude/settings.json` holds six keys. All are cross-machine preferences — no `{{ if .is_work }}` branching needed today.
+
+| Field | Value | Why pinned |
+|---|---|---|
+| `$schema` | `json.schemastore.org/claude-code-settings.json` | Autocomplete + inline validation in any JSON-schema-aware editor. Zero runtime cost. |
+| `hooks.PreToolUse[Bash]` | `npx block-no-verify@1.1.2` | Intercepts `git commit --no-verify` / `git push --no-verify` — matches the "never skip hooks" rule in CLAUDE.md. |
+| `statusLine` | `bash -c '... bun … claude-hud/src/index.ts'` | Picks highest-versioned claude-hud install, execs it via bun. Hardcoded `/opt/homebrew/bin/bun` is fine on Apple Silicon Macs (both of ours). |
+| `enabledPlugins` | 3 entries | `claude-hud` (status HUD) · `codex` (OpenAI Codex lifecycle hooks) · `andrej-karpathy-skills` (skill pack). |
+| `extraKnownMarketplaces` | 3 GitHub sources | Registers the `github:owner/repo` marketplaces that satisfy `enabledPlugins`. Needed on a fresh Mac before Claude can resolve plugin IDs. |
+| `syntaxHighlightingDisabled` | `true` | Response highlighting has intermittent terminal-render bugs in ghostty — killed it, prefer plain. |
+| `effortLevel` | `"xhigh"` | Claude's [extended-thinking budget](https://code.claude.com/docs/en/model-config#adjust-effort-level). Persisted automatically when you run `/effort`; pin it so new Macs don't default back to medium. |
+
+## Runtime exclusions (why each is ignored)
+
+`.chezmoiignore` blocks the following from ever entering source control:
+
+| Path | Contains | Why not cross-machine |
+|---|---|---|
+| `dot_claude/settings.local.json` | Per-project Bash/WebFetch allowlists | Paths are `/Users/bytedance/...` — worthless on another Mac. Also holds bytedance-internal allowlist entries. |
+| `dot_claude/sessions/` | JSONL transcripts of every Claude run | Grows to MB/day. Resume data, not config. |
+| `dot_claude/projects/<proj>/memory/` | Auto-memory files Claude writes itself | Docs: **machine-local by design**. Sharing would collide between work and personal. |
+| `dot_claude/plans/` | `/plan` mode outputs | Work artifacts, not config. Our `0-1-dotfiles-*.md` plan lives here locally; each machine has its own. |
+| `dot_claude/plugins/` | Marketplace cache + install metadata | Re-created on launch from `enabledPlugins` + `extraKnownMarketplaces`. Includes `blocklist.json` and `install-counts-cache.json` which churn. |
+| `dot_claude/cache/` `image-cache/` `paste-cache/` | Throwaway caches | — |
+| `dot_claude/file-history/` `shell-snapshots/` | Undo / command history | Per-session; huge. |
+| `dot_claude/tasks/` | Background subagent outputs | Per-invocation. |
+| `dot_claude/telemetry/` `metrics/` `homunculus/` | Usage telemetry | Anthropic-internal shape, machine-specific. |
+| `dot_claude/session-data/` `session-env/` | Current-session env snapshots | Per-session. |
+| `dot_claude/chrome/` `downloads/` | Browser-extension cache | Machine-local. |
+| `dot_claude/*.jsonl` `*.log` `*-cache.json` | `history.jsonl`, `bash-commands.log`, `cost-tracker.log`, `stats-cache.json` | Logs and caches. |
+| `dot_claude/agents/` `skills/` `commands/` `rules/` `CLAUDE.md` | **Unused extension points** | Not currently populated. Pre-emptively ignored so a stray `chezmoi add ~/.claude` can't silently start versioning something we haven't evaluated. Delete the ignore entry before opting any of these into source. |
+
+## Scopes cheat-sheet (2026)
+
+Precedence high→low, same as [upstream docs](https://code.claude.com/docs/en/settings#settings-precedence):
+
+```
+managed (MDM/server)     ← IT, can't be overridden
+CLI flags                ← one session
+.claude/settings.local.json (project, gitignored)
+.claude/settings.json       (project, shared)
+~/.claude/settings.json     ← we manage this
+```
+
+So our `dot_claude/settings.json` is the **lowest-precedence** layer — project-level settings always win. That's desirable: projects should be free to tighten permissions or swap the model without fighting `~/.claude/`.
+
+## Hooks at a glance
+
+Claude Code now supports **29 lifecycle events** × **4 handler types** (`command` / `http` / `prompt` / `agent`). We use one:
+
+- **PreToolUse, matcher=Bash** → `npx block-no-verify@1.1.2`. Runs before every Bash tool call; exits non-zero → Claude is told the command was blocked.
+
+Hooks we intentionally *don't* configure at user level:
+
+- Plugin `.mjs` hooks (e.g. `openai-codex` SessionStart/SessionEnd/Stop) live in `~/.claude/plugins/cache/openai-codex/…/hooks/hooks.json` — installed by the plugin itself when `enabledPlugins` references it. **We don't duplicate them in `settings.json`.**
+- Anything project-scoped (e.g. PostToolUse lint hooks) belongs in that project's `.claude/settings.json`, not here.
+
+## Plugin model (preview — full story in Phase 6c)
+
+`enabledPlugins` + `extraKnownMarketplaces` is a **declaration**, not a vendoring. On `~/.claude/plugins/` being empty, Claude re-fetches from GitHub on next launch.
+
+Three plugins are currently declared:
+
+| Plugin | What it ships | Namespace |
+|---|---|---|
+| `claude-hud@claude-hud` | `statusLine` backend (the bun script pointed to by our `statusLine` field) | — |
+| `codex@openai-codex` | `.mjs` SessionStart / SessionEnd / Stop hooks | `/codex:*` skills |
+| `andrej-karpathy-skills@karpathy-skills` | Skill pack | `/karpathy-skills:*` skills |
+
+> **Company-internal plugins / MCPs** (e.g. `feishu-lark-mcp`, `bytedcli`) are **not** declared here. They're work-Mac-only, auth-token-dependent, and documented in the internal Feishu runbook instead — Phase 6c will wire that up.
+
+---
+
+## Using Claude Code effectively
+
+This section is the "how to actually use it" companion to the config above. Everything here is a feature Claude Code *already ships* — no setup needed beyond the six fields we pinned. Pulled from the 2026 docs (last fetched during Phase 6b).
+
+### Core mental model
+
+| Concept | Lives in | When to reach for it |
+|---|---|---|
+| **Conversation / session** | `~/.claude/sessions/` | One chat thread. `/resume` picks one up. `/clear` starts a new one; old one still resumable. |
+| **Context window** | Runtime memory | Everything Claude can "see" in this turn. Finite. `/context` shows what's eating it. |
+| **Checkpoint** | `~/.claude/file-history/` | Pre-edit file snapshot. `Esc` `Esc` or `/rewind` restores. **Not** tracked for bash `rm`/`mv`. |
+| **CLAUDE.md** | Markdown, user/project | You write; Claude reads at session start. Soft rule, always in context. |
+| **Auto-memory** | `~/.claude/projects/<proj>/memory/MEMORY.md` | Claude writes itself. First 200 lines auto-loaded. **Machine-local** — doesn't sync across Macs. |
+| **Skill** | `SKILL.md` (+ optional files) | On-demand playbook. Loads when invoked or when Claude sees a match. |
+| **Subagent** | `~/.claude/agents/<name>.md` | Forked context window for side tasks (explore, review). Parent only sees the summary. |
+
+### Permission modes (Shift+Tab cycles them)
+
+The mode sets the baseline — what runs without asking. Layer per-tool `allow` / `deny` rules in `/permissions` on top.
+
+| Mode | What runs without asking | When to use |
+|---|---|---|
+| `default` | Reads only | New task, sensitive work, "I want to review each edit" |
+| `acceptEdits` | Reads + file edits + `mkdir` / `touch` / `mv` / `cp` / `rm` / `sed` | Iterating on code you'll review afterward via `git diff` |
+| `plan` | Reads only, **no edits** — Claude proposes a plan then stops | Exploring before changing. Claude delegates research to the **Plan** subagent. |
+| `auto` | Everything, with a classifier blocking escalations | Long autonomous tasks (requires Max/Team/Ent plan + Sonnet 4.6 / Opus 4.6+) |
+| `dontAsk` | Only `allow`-listed tools + read-only bash | Locked-down CI / scripted runs |
+| `bypassPermissions` | Everything (except protected paths) | **Isolated VMs only.** Started with `--dangerously-skip-permissions`. |
+
+**Protected paths** are *never* auto-approved in any mode: `.git`, `.vscode`, `.idea`, `.husky`, `.claude` (except `.claude/commands`, `agents`, `skills`, `worktrees`), `.gitconfig`, `.zshrc`, `.mcp.json`, `.claude.json`.
+
+### Keyboard shortcuts — the actually-useful subset
+
+| Keys | What it does |
+|---|---|
+| `Shift+Tab` | **Cycle permission mode** (default → acceptEdits → plan → auto*) |
+| `Esc` | Interrupt current turn / cancel menu |
+| `Esc` `Esc` | **Rewind / checkpoint menu** — restore code, conversation, or both to an earlier prompt |
+| `Ctrl+O` | Toggle transcript viewer (see every tool call + its result) |
+| `Ctrl+G` | Open external editor for the prompt (multi-paragraph prompts) |
+| `Ctrl+T` | Toggle task-list panel |
+| `Ctrl+R` | Reverse-search prompt history |
+| `Ctrl+B` | Background the current bash command (tmux users press twice) |
+| `Ctrl+X Ctrl+K` | Kill all background agents (press twice in 3s to confirm) |
+| `Ctrl+V` / `Cmd+V` | Paste image — becomes an `[Image #N]` chip you can reference |
+| `\` + `Enter` | Multiline input (works everywhere; `Shift+Enter` works in Ghostty/iTerm2/WezTerm/Kitty) |
+| `/` at start | Slash-command / skill picker |
+| `!` at start | **Bash mode** — run a shell cmd directly and add output to context |
+| `@` | File-path autocomplete — pull a file into the conversation |
+| `#` (followed by text) | Add to CLAUDE.md / auto-memory via prompt |
+
+`*` auto only appears in the cycle if your plan supports it.
+
+### Slash commands — researcher's pick-list
+
+Type `/` for the full menu. The ones that actually earn their keystrokes for our use case:
+
+**Session management**
+- `/clear` (= `/reset`, `/new`) — new conversation, old one still resumable
+- `/resume` / `/continue` — open session picker (or pass an ID)
+- `/branch [name]` — fork current conversation at this point
+- `/rewind` — same as `Esc` `Esc` (checkpoint menu)
+- `/compact [focus]` — summarize conversation to free context; optionally give focus hints
+- `/context` — visualize what's eating the context window
+- `/diff` — interactive diff viewer (git diff + per-turn diffs)
+
+**Modes & effort**
+- `/plan [description]` — enter plan mode directly
+- `/effort low|medium|high|xhigh|max|auto` — session-level thinking budget
+- `/fast` — toggle fast Opus 4.6 (2.5× faster, higher $ — use for interactive iteration)
+- `/model` — pick a model; for models that support effort, arrows adjust it
+- `/permissions` — add/remove allow/ask/deny rules interactively
+
+**Skills & agents**
+- `/skills` — list all skills (`t` sorts by token cost)
+- `/agents` — list/create/edit subagents
+- `/hooks` — view all configured hooks
+
+**Bundled skills — researcher gold**
+- `/claude-api` — load Claude API reference for your language (Python/TS/…) + Managed Agents reference. Auto-activates when you import `anthropic`. Huge for a researcher writing against the API.
+- `/simplify [focus]` — spawn 3 parallel review agents on your recently-changed files, aggregate, apply fixes
+- `/debug [description]` — turn on debug logging, troubleshoot issues
+- `/review [PR]` — local PR review
+- `/security-review` — scan pending changes for injection / auth / data-exposure risks
+- `/loop [interval] [prompt]` — run prompt repeatedly; omit interval and Claude self-paces. Killer for monitoring long experiments.
+- `/fewer-permission-prompts` — scan your transcript, allowlist common read-only bash calls you've been re-approving
+
+**Introspection**
+- `/status` — version, model, account, which settings source wins each field
+- `/doctor` — diagnose install + config (`f` auto-fixes)
+- `/cost` — token usage so far
+- `/insights` — analyze your last 30 days of sessions (friction points, favorite models)
+- `/stats` — daily-usage graph
+- `/recap` — one-line session summary
+
+**External**
+- `/mcp` — MCP server connections
+- `/plugin` — marketplace browser
+- `/export [file]` — dump conversation as plain text
+- `/copy [N]` — copy Nth-latest assistant response (with code-block picker)
+- `/btw <q>` — quick side question using current context, **doesn't enter conversation history**
+
+### Plan mode — when to reach for it
+
+Workflow: `Shift+Tab` until "plan" → describe the task → Claude researches (delegating to the **Plan** subagent for reads) → proposes a plan → you pick:
+
+1. **Approve + auto** — execute hands-off (if `auto` is available)
+2. **Approve + accept edits** — execute, skip edit prompts
+3. **Approve + manual** — execute, prompt each edit
+4. **Keep planning with feedback** — iterate
+5. **Refine with Ultraplan** — browser-based multi-agent review (requires subscription)
+
+Each approval option also offers to **clear the planning context first** — useful when the research phase bloated context but the implementation is small.
+
+For big refactors, the "plan then acceptEdits" flow is the sweet spot: you review the plan (cheap, focused) instead of reviewing every edit (expensive, noisy).
+
+### Subagents — the actually-often-used feature
+
+Subagents = forked context windows. You get the summary; the main conversation doesn't see the search results.
+
+**Built-ins, always available:**
+
+| Agent | Model | Tools | When it fires |
+|---|---|---|---|
+| **Explore** | Haiku | Read-only | Claude delegates when it needs to search/understand code without changing it. Thoroughness levels: `quick`/`medium`/`very thorough`. |
+| **Plan** | Inherits | Read-only | Plan mode's research helper. Prevents infinite nesting. |
+| **general-purpose** | Inherits | All | Complex multi-step work that needs both exploration and action. |
+| **statusline-setup** | Sonnet | — | Runs when you invoke `/statusline`. |
+| **Claude Code Guide** | Haiku | — | Answering questions about Claude Code itself. |
+
+**Explore is the single most useful feature for reading a new codebase or paper repo.** Ask "how does the training loop work in this repo?" — Claude fires Explore, gets back a summary in one reply, and your main conversation stays clean.
+
+**Custom subagents** live at `~/.claude/agents/<name>.md`. Create via `/agents` (interactive, can "Generate with Claude") or by hand — it's just Markdown + YAML frontmatter:
+
+```markdown
+---
+name: paper-reader
+description: Read an ML paper PDF/repo and summarize the method, novelty, and limitations. Use when the user drops a paper URL or asks "what's new in this paper?"
+tools: Read, Grep, Glob, WebFetch
+model: sonnet
+---
+
+When reading a paper:
+1. Method: one paragraph, equations inline
+2. Novelty: what's different from the closest prior work?
+3. Limitations: what the authors didn't say but a reviewer would
+4. Reproducibility: does the repo match the paper?
+```
+
+Store at `~/.claude/agents/paper-reader.md` → available in every project. Invoke: `Use the paper-reader agent to summarize …`.
+
+`/agents` → "Running" tab shows active subagents; you can open one's transcript or stop it.
+
+### Agent Teams — for parallel debate (experimental)
+
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` unlocks it. Multiple independent Claude sessions with a shared task list; teammates can **message each other** (subagents can't). The lead synthesizes.
+
+Researcher scenarios where this earns the token cost:
+
+- **Competing-hypothesis debugging**: "5 teammates investigate different hypotheses for why loss diverges at step 8k. Talk to each other to disprove theories. Update the findings doc with whatever consensus emerges."
+- **Parallel review**: "Review PR #142 — security teammate, performance teammate, test-coverage teammate. Each reports separately."
+- **Multi-angle design**: "CLI design — one teammate on UX, one on architecture, one playing devil's advocate."
+
+Rules of thumb: 3–5 teammates, 5–6 tasks each, start with research/review (not implementation — file conflicts). Token cost scales linearly, so use when parallel exploration genuinely beats sequential.
+
+### Skills — what's bundled, what to write
+
+**Bundled skills** ship with Claude Code; same `/` namespace as your own. Worth knowing by heart: `/claude-api`, `/simplify`, `/debug`, `/loop`, `/review`, `/security-review`, `/init` (bootstrap a CLAUDE.md), `/team-onboarding` (generate an onboarding doc from your last 30 days).
+
+**Custom skills** live at `~/.claude/skills/<name>/SKILL.md` (user-level) or `.claude/skills/…` (project-level). Frontmatter controls who can invoke + what tools are pre-approved:
+
+```yaml
+---
+name: benchmark-run
+description: Run the benchmark suite, capture wall-clock + peak memory, format as a table
+disable-model-invocation: true   # only I can invoke, not Claude
+allowed-tools: Bash(python bench/*.py)  Bash(/usr/bin/time *)
+argument-hint: [config-file]
+---
+
+Run `python bench/run.py $ARGUMENTS`, capture stderr from /usr/bin/time,
+emit a markdown table with columns: config, wall_s, peak_rss_mb, tokens/s.
+```
+
+`disable-model-invocation: true` is the killer field for skills that have **side effects** (deploy, benchmark, send-slack) — Claude won't silently trigger them. `user-invocable: false` is the inverse, for background knowledge Claude should know but you'd never type `/` to pull up.
+
+### Headless mode — Claude Code as a shell tool
+
+`claude -p "…"` runs non-interactively. Useful for:
+
+```bash
+# Review a diff in CI
+gh pr diff 123 | claude -p --append-system-prompt "Security reviewer. Flag injection, authz, secrets." --output-format json
+
+# Auto-commit staged changes
+claude -p "Review staged changes and create a commit" --allowedTools "Bash(git diff *),Bash(git commit *)"
+
+# Extract structured data
+claude -p "List function names from auth.py" \
+  --output-format json \
+  --json-schema '{"type":"object","properties":{"functions":{"type":"array","items":{"type":"string"}}}}' \
+  | jq '.structured_output.functions'
+
+# Same result on every machine (skip auto-discovery):
+claude --bare -p "Summarize this paper" --allowedTools "Read"
+```
+
+`--bare` is the recommended mode for scripts: no CLAUDE.md / hooks / plugins / MCP / auto-memory. Reproducible. Combine with `--append-system-prompt-file` to keep the prompt under version control.
+
+### Researcher playbook — scenarios that earn their keep
+
+**1. Reading a new paper's repo.** Open Claude Code in the repo. First prompt: `Use the Explore agent (very thorough) to map the training pipeline: how data is loaded, how losses are composed, what the eval setup is. Return a markdown outline with file:line refs.` Your main context stays clean, you get a navigable outline.
+
+**2. Debugging a flaky training run.** `/plan the root cause of the NaN at step 8k`. Claude (in plan mode) reads log files, config, model code — read-only, doesn't touch anything. Presents 2–3 hypotheses. You pick one, hit "Approve + accept edits", it implements the fix.
+
+**3. Big refactor across 20 files.** Plan mode → review the plan → "Approve + acceptEdits" → let it run. Use `Esc` `Esc` (`/rewind`) if it derails mid-way. `git diff` at the end is your review surface.
+
+**4. Long experiment watcher.** `/loop 10m check if training crashed or loss hit target; if so, commit and post to slack`. Or without an interval: `/loop` lets Claude self-pace. Useful for "wake me when it's done" workflows.
+
+**5. Learning the Claude API itself.** `/claude-api` loads the Python reference for your language — tool use, streaming, batches, structured outputs, pitfalls. Then ask: `write a minimal agent that uses tool_choice: any and handles rate-limit retries`.
+
+**6. Frontend you can't debug.** Let auto-memory accumulate ("last session we found the Tailwind class conflict was actually from the purge list"). Use `Esc` `Esc` liberally — if an edit broke the UI, rewind to the last-known-good and try a different approach. Couple with `/simplify` after a session to clean up code the model left messy.
+
+**7. PR review you'd delegate to a colleague.** `/review <PR#>` for a local pass; `/ultrareview <PR#>` for a deeper cloud-based multi-agent pass (3 free on Pro/Max, then billed). Or spin up an Agent Team: "3 reviewers — security, performance, tests — each reports findings."
+
+**8. Data pipeline scripts.** `acceptEdits` mode + `claude -p --bare` for scripts you want to re-run identically. Pre-approve `Bash(python …)` + `Bash(head|wc|ls …)` in project settings so the loop doesn't pause on every tool call.
+
+### Costs / throttles / escape hatches
+
+- `/cost` shows token usage for the session; `/usage` shows plan quota; `/stats` is the dashboard.
+- `/fast` is 2.5× faster but also 2.5× the cost per token and eats **extra usage**, not plan quota. Toggle off for long unattended runs.
+- `/effort low` vs `xhigh` — lower = less thinking time = faster/cheaper = maybe wrong on hard tasks. Our default is `xhigh` (pinned). Drop to `medium` for throwaway tasks via `/effort`.
+- Hit a wall? `/compact [focus]` summarizes the conversation (keeps CLAUDE.md + rules). `/rewind` can restore to a pre-bloat point. `/clear` nukes and starts fresh.
+
+---
+
+## Change a setting
+
+1. Edit `dot_claude/settings.json`.
+2. `chezmoi diff ~/.claude/settings.json` — review the rendered diff.
+3. `chezmoi apply ~/.claude/settings.json`.
+4. Add a regression guard in `tests/claude.sh` under **Pinned settings fields** if the new value is something we care about keeping.
+5. Restart Claude Code (`Ctrl+D` / exit, re-launch) — most settings are read at startup only.
+
+## Health check
+
+### Automated
+
+```bash
+bash tests/claude.sh
+```
+
+~38 checks: binary presence (`claude`, `bun`, `npx`, `node`), source + target JSON validity, every pinned field, all `.chezmoiignore` runtime exclusions, plugin-cache populated, smoke for `claude --version` + `npx block-no-verify` resolution.
+
+### Manual
+
+- [ ] `claude --version` runs cleanly
+- [ ] `claude` launches interactively, statusLine renders (claude-hud bun output)
+- [ ] `/hooks` lists the PreToolUse Bash hook + all plugin hooks, zero "command not found" errors
+- [ ] `/status` shows `~/.claude/settings.json` as the source for `effortLevel: xhigh` and `syntaxHighlightingDisabled: true`
+- [ ] Attempting `git commit --no-verify` inside a Claude session is blocked by the PreToolUse hook
+- [ ] `/plugin list` shows `claude-hud`, `codex`, `andrej-karpathy-skills` all enabled
+- [ ] On the **other** machine after `chezmoi apply`: the same six fields are present in `~/.claude/settings.json`
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `claude: command not found` | Claude Code not installed | `bootstrap.sh` runs the installer; one-off: `curl -fsSL https://claude.ai/install.sh \| bash` |
+| `statusLine` is blank | `claude-hud` plugin not installed yet (empty `~/.claude/plugins/cache/claude-hud/`) | `claude plugin install claude-hud@claude-hud`, then restart |
+| `statusLine` fails with `bun: No such file` | `bun` missing from `/opt/homebrew/bin/bun` | Currently installed as a Claude Code dependency; if absent, `brew install oven-sh/bun/bun` |
+| PreToolUse hook: `node: command not found` or `npx: command not found` | `node` missing (Phase 2 fix regression) | `brew bundle` — Brewfile declares `node`. Root cause check in `docs/brewfile.md`. |
+| Plugin `.mjs` hooks all fail at session start | `node` missing (same as above) — `openai-codex` lifecycle hooks shell out to `node` | Same fix: `brew bundle` |
+| `syntaxHighlightingDisabled: true` seems ignored | A newer Claude Code release changed the key name | Check upstream [settings reference](https://code.claude.com/docs/en/settings) — this is an area actively evolving |
+| Auto-memory growing huge | Per-project `~/.claude/projects/<proj>/memory/MEMORY.md` > 200 lines → content beyond the threshold stops auto-loading | Run `/memory`, prune, or let Claude offload to topic files |
+| `chezmoi apply` tries to create `~/.claude/sessions/` / `~/.claude/cache/` | An ignore pattern was deleted | Restore it in `.chezmoiignore` — `tests/claude.sh` will flag which |
+
+## Gotchas
+
+- **`enabledPlugins` is declarative, not a vendor.** Wiping `~/.claude/plugins/` and re-launching re-downloads from the marketplaces. First launch on a fresh Mac needs network to GitHub.
+- **`statusLine` hard-codes `/opt/homebrew/bin/bun`.** Fine on Apple Silicon (both our Macs). Would break on Intel or Linux — a future `dot_claude/settings.json.tmpl` could use `{{ env "HOMEBREW_PREFIX" }}` or expand `$(command -v bun)` if this ever ships cross-arch.
+- **Don't `chezmoi add ~/.claude`.** It recurses into runtime subdirs — the `.chezmoiignore` blocks most, but adding whole-dir can still surprise. Add individual files instead (`chezmoi add ~/.claude/settings.json`).
+- **`~/.claude/settings.local.json` is never tracked** but chezmoi also never manages it, so editing it locally is safe — it's entirely out of band.
+- **Auto-memory is machine-local.** If you've been building up good MEMORY.md entries on the work Mac, they don't follow you home. That's by design ([upstream docs](https://code.claude.com/docs/en/memory#storage-location)); if you want cross-machine rules, write them into `~/.claude/CLAUDE.md` and version *that* in a future phase.
+- **The old `includeCoAuthoredBy` key is deprecated.** Not in our settings today. When we do need commit attribution control, use the newer `attribution` object — covered in the 2026 settings docs.
+
+## Rebuild from scratch
+
+If `~/.claude/settings.json` gets clobbered:
+
+```bash
+chezmoi apply ~/.claude/settings.json
+```
+
+If plugin cache rots (wrong versions, partial installs):
+
+```bash
+rm -rf ~/.claude/plugins
+# Restart Claude Code — enabledPlugins + extraKnownMarketplaces trigger a refetch.
+```
+
+If auto-memory gets confused (wrong or outdated entries for *this* project):
+
+```bash
+rm -rf ~/.claude/projects/<proj>/memory
+# Claude starts fresh, will re-accumulate. Safe because it's per-machine anyway.
+```
+
+---
+
+## Related
+
+- [`Brewfile`](../Brewfile) — `node` is declared there; the inline comment covers why Claude Code plugin hooks need it
+- [Claude Code settings reference](https://code.claude.com/docs/en/settings)
+- [Claude Code hooks reference](https://code.claude.com/docs/en/hooks)
+- [Claude Code memory reference](https://code.claude.com/docs/en/memory)
+- **Phase 6c** (upcoming) — plugins / MCP / skills deep-dive + internal-vs-external split

--- a/docs/claude.zh.md
+++ b/docs/claude.zh.md
@@ -1,0 +1,423 @@
+# Claude Code
+
+> [English](claude.md) · 中文
+
+跨机 Claude Code 配置：**只管 `~/.claude/settings.json` 一份。** `~/.claude/` 下其他内容 —— sessions、auto-memory、插件缓存、session-env、日志、allowlist —— 都是本机 runtime 状态，**故意排除**（见 `.chezmoiignore`）。
+
+Phase 6c 会单独处理 plugins / MCP / skills；本 phase 只管 settings 主干。
+
+## 运作方式
+
+| 源（repo） | 目标（`$HOME`） | 行为 |
+|---|---|---|
+| `dot_claude/settings.json` | `~/.claude/settings.json` | 普通拷贝。不用模板 —— 当前所有字段都跨机通用。 |
+| _（排除）_ | `~/.claude/settings.local.json` | 项目级 permission allowlist；全是本机特有路径。 |
+| _（排除）_ | `~/.claude/sessions/` `projects/` `plans/` `cache/` `…` | 纯运行时 —— 见下文 **Runtime 排除**。 |
+
+`chezmoi apply` 把 `dot_claude/settings.json` 渲染到 `~/.claude/settings.json`。没有 hook 脚本，没有插件重装 —— `enabledPlugins` 只是声明意图，Claude 自己的 marketplace fetcher 在下次启动时会拉取。
+
+## 两种持久化机制（为什么只管一种）
+
+Claude Code 有**两套**跨 session 的记忆机制。repo 里只 version 第一套：
+
+| | **Settings** (`settings.json`) | **Memory** (`CLAUDE.md` + auto-memory) |
+|---|---|---|
+| 写入方 | 你，声明式 JSON | 你写 `CLAUDE.md`；Claude 写 auto-memory |
+| 约束强度 | 硬 —— `deny` 规则和 hooks 能拦截 tool 调用 | 软 —— 以 user message 注入上下文，不强制 |
+| 跨机共享 | 是（只要进 repo） | **否 —— auto-memory 按[官方文档](https://code.claude.com/docs/en/memory#storage-location)就是 machine-local** |
+| 我们的 repo | `dot_claude/settings.json` | 暂未纳入；user-level `CLAUDE.md` 也还没 track |
+
+第二套值得知道但**绝不能进 repo**：`~/.claude/projects/<proj>/memory/MEMORY.md` 是 per-working-tree 的产物，共享给另一台 Mac 会互相污染。
+
+## 固定字段
+
+`dot_claude/settings.json` 六个 key，全部跨机通用 —— 今天还不需要 `{{ if .is_work }}` 分支。
+
+| 字段 | 值 | 为什么 pin |
+|---|---|---|
+| `$schema` | `json.schemastore.org/claude-code-settings.json` | 任何支持 JSON schema 的编辑器都能自动补全 + 即时校验，零运行时成本。 |
+| `hooks.PreToolUse[Bash]` | `npx block-no-verify@1.1.2` | 拦截 `git commit --no-verify` / `git push --no-verify` —— 呼应 CLAUDE.md 里"绝不跳 hook"那条。 |
+| `statusLine` | `bash -c '... bun … claude-hud/src/index.ts'` | 选最高版本的 claude-hud，用 bun 执行。硬编码 `/opt/homebrew/bin/bun` 在 Apple Silicon Mac 上没问题（咱两台都是）。 |
+| `enabledPlugins` | 3 项 | `claude-hud`（状态 HUD）· `codex`（OpenAI Codex 生命周期 hooks）· `andrej-karpathy-skills`（技能包）。 |
+| `extraKnownMarketplaces` | 3 个 GitHub 源 | 注册 `github:owner/repo` 类 marketplace，`enabledPlugins` 才能解析。新 Mac 首启必需。 |
+| `syntaxHighlightingDisabled` | `true` | 回复高亮在 ghostty 偶发渲染 bug —— 关了，偏好纯文本。 |
+| `effortLevel` | `"xhigh"` | Claude 的[思考预算](https://code.claude.com/docs/en/model-config#adjust-effort-level)。跑 `/effort` 会自动持久化；pin 住防止新 Mac 回退成 medium。 |
+
+## Runtime 排除（为什么每个都 ignore）
+
+`.chezmoiignore` 阻止以下内容进入源：
+
+| 路径 | 内容 | 为什么不跨机 |
+|---|---|---|
+| `dot_claude/settings.local.json` | 项目级 Bash / WebFetch allowlist | 路径都是 `/Users/bytedance/...`，另一台 Mac 没用。还混了字节内部的 allow 条目。 |
+| `dot_claude/sessions/` | 每次跑 Claude 的 JSONL 对话记录 | 每天 MB 级增长。Resume 数据，不是配置。 |
+| `dot_claude/projects/<proj>/memory/` | Claude 自己写的 auto-memory | 文档明确说**按设计就是 machine-local**。共享会让工作机 / 个人机互相污染。 |
+| `dot_claude/plans/` | `/plan` 模式输出 | 工作产物，不是配置。本地 `0-1-dotfiles-*.md` plan 就放在这，每台机各有一份。 |
+| `dot_claude/plugins/` | Marketplace 缓存 + 安装元数据 | 启动时根据 `enabledPlugins` + `extraKnownMarketplaces` 重建。包含常变的 `blocklist.json` 和 `install-counts-cache.json`。 |
+| `dot_claude/cache/` `image-cache/` `paste-cache/` | 随机缓存 | — |
+| `dot_claude/file-history/` `shell-snapshots/` | 撤销 / 命令历史 | Per-session；体积大。 |
+| `dot_claude/tasks/` | 后台 subagent 输出 | Per-invocation。 |
+| `dot_claude/telemetry/` `metrics/` `homunculus/` | 用量埋点 | Anthropic 内部 schema，机器特有。 |
+| `dot_claude/session-data/` `session-env/` | 当前 session 环境快照 | Per-session。 |
+| `dot_claude/chrome/` `downloads/` | 浏览器扩展缓存 | 本机。 |
+| `dot_claude/*.jsonl` `*.log` `*-cache.json` | `history.jsonl`、`bash-commands.log`、`cost-tracker.log`、`stats-cache.json` | 日志和缓存。 |
+| `dot_claude/agents/` `skills/` `commands/` `rules/` `CLAUDE.md` | **未使用的扩展点** | 当前都没内容。预先 ignore，防止误 `chezmoi add ~/.claude` 悄悄版本化未审查的东西。要纳入 repo 前先删这条 ignore。 |
+
+## Scope 速查（2026）
+
+优先级由高到低，跟[官方文档](https://code.claude.com/docs/en/settings#settings-precedence)一致：
+
+```
+managed (MDM/server)     ← IT 管，不可覆盖
+CLI flags                ← 单 session
+.claude/settings.local.json (项目级，git 忽略)
+.claude/settings.json       (项目级，入库共享)
+~/.claude/settings.json     ← 我们管这层
+```
+
+所以 `dot_claude/settings.json` 是**优先级最低**的一层 —— 项目级 settings 永远胜过它。这是有意的：项目有权收紧权限或换模型而不被 `~/.claude/` 盖掉。
+
+## Hooks 速览
+
+Claude Code 现支持 **29 个生命周期事件** × **4 种 handler 类型**（`command` / `http` / `prompt` / `agent`）。我们只用一个：
+
+- **PreToolUse, matcher=Bash** → `npx block-no-verify@1.1.2`。每次 Bash 工具调用前触发；非零退出码告诉 Claude 命令被拦截。
+
+我们**故意不在 user 级配**的 hooks：
+
+- 插件自带的 `.mjs` hooks（如 `openai-codex` 的 SessionStart/SessionEnd/Stop）住在 `~/.claude/plugins/cache/openai-codex/…/hooks/hooks.json` —— 插件自己安装，当 `enabledPlugins` 引用时生效。**我们不在 `settings.json` 里重复定义。**
+- 项目级 hooks（如 PostToolUse 的 lint）属于该项目的 `.claude/settings.json`，不属于这里。
+
+## 插件模型（概览 —— Phase 6c 详讲）
+
+`enabledPlugins` + `extraKnownMarketplaces` 是**声明**，不是 vendor。`~/.claude/plugins/` 空的情况下，Claude 会在下次启动重新拉取。
+
+当前声明的三个插件：
+
+| 插件 | 提供 | Namespace |
+|---|---|---|
+| `claude-hud@claude-hud` | `statusLine` 后端（我们 `statusLine` 字段指向的 bun 脚本） | — |
+| `codex@openai-codex` | `.mjs` SessionStart / SessionEnd / Stop hooks | `/codex:*` skills |
+| `andrej-karpathy-skills@karpathy-skills` | 技能包 | `/karpathy-skills:*` skills |
+
+> **公司内部插件 / MCPs**（如 `feishu-lark-mcp`、`bytedcli`）**不**在这里声明。它们工作机专用、依赖内网 token，记录在内部飞书 runbook —— Phase 6c 会接入。
+
+---
+
+## 高效使用 Claude Code
+
+这一段是上面配置的"怎么实际用"伴读。本节所有功能都是 Claude Code **自带**的 —— 无需在咱 pin 的 6 个字段之外再做任何配置。内容抓自 2026 官方文档（Phase 6b 期间抓取）。
+
+### 核心心智模型
+
+| 概念 | 住在 | 什么时候想它 |
+|---|---|---|
+| **对话 / session** | `~/.claude/sessions/` | 一条聊天线。`/resume` 把某条接回来。`/clear` 开新的；旧的仍可 resume。 |
+| **Context window** | 运行时内存 | Claude 这一轮能"看到"的所有东西。有限。`/context` 看谁在吃。 |
+| **Checkpoint** | `~/.claude/file-history/` | 编辑前的文件快照。`Esc` `Esc` 或 `/rewind` 恢复。**不**追踪 bash 的 `rm`/`mv`。 |
+| **CLAUDE.md** | Markdown, user / project | 你写；Claude 在 session 启动时读。软规则，始终在 context 里。 |
+| **Auto-memory** | `~/.claude/projects/<proj>/memory/MEMORY.md` | Claude 自己写。前 200 行自动加载。**Machine-local** —— 不跨机同步。 |
+| **Skill** | `SKILL.md`（+ 可选附件） | 按需加载的 playbook。被调用或 Claude 觉得相关时载入。 |
+| **Subagent** | `~/.claude/agents/<name>.md` | 为侧任务 fork 的 context（探索、评审）。父 session 只看摘要。 |
+
+### Permission 模式（Shift+Tab 循环）
+
+模式设定 baseline —— 什么不问直接跑。在 `/permissions` 里按工具加 `allow` / `deny` 规则作为叠加层。
+
+| 模式 | 不问直接跑的范围 | 什么时候用 |
+|---|---|---|
+| `default` | 只读 | 新任务 / 敏感工作 / "我想审核每次编辑" |
+| `acceptEdits` | 读 + 文件编辑 + `mkdir` / `touch` / `mv` / `cp` / `rm` / `sed` | 迭代你会用 `git diff` 事后审的代码 |
+| `plan` | 只读，**不编辑** —— Claude 提方案然后停 | 动手前先探索。Claude 把研究工作委托给 **Plan** subagent。 |
+| `auto` | 所有操作，但分类器拦截升级动作 | 长时间自动任务（需要 Max / Team / Enterprise 方案 + Sonnet 4.6 / Opus 4.6+） |
+| `dontAsk` | 只有 `allow` 列表里的工具 + 只读 bash | 锁死的 CI / 脚本 |
+| `bypassPermissions` | 所有（除 protected paths） | **仅隔离 VM 用。** 启动时加 `--dangerously-skip-permissions`。 |
+
+**Protected paths** 任何模式都**不会**自动批准：`.git`、`.vscode`、`.idea`、`.husky`、`.claude`（除 `.claude/commands`、`agents`、`skills`、`worktrees`）、`.gitconfig`、`.zshrc`、`.mcp.json`、`.claude.json`。
+
+### 快捷键 —— 真正有用的那部分
+
+| 按键 | 作用 |
+|---|---|
+| `Shift+Tab` | **切换权限模式**（default → acceptEdits → plan → auto*） |
+| `Esc` | 中断当前 turn / 关闭菜单 |
+| `Esc` `Esc` | **Rewind / checkpoint 菜单** —— 把代码、对话、或两者回滚到更早的 prompt |
+| `Ctrl+O` | 切换 transcript viewer（看每次 tool 调用及其结果） |
+| `Ctrl+G` | 外部编辑器打开 prompt（写多段长 prompt 用） |
+| `Ctrl+T` | 切换 task-list 面板 |
+| `Ctrl+R` | 反向搜索 prompt 历史 |
+| `Ctrl+B` | 后台化当前 bash 命令（tmux 用户按两次） |
+| `Ctrl+X Ctrl+K` | 杀光后台 agents（3s 内按两次确认） |
+| `Ctrl+V` / `Cmd+V` | 粘贴图片 —— 变成可引用的 `[Image #N]` chip |
+| `\` + `Enter` | 多行输入（到处能用；`Shift+Enter` 在 Ghostty / iTerm2 / WezTerm / Kitty 开箱即用） |
+| `/` 开头 | Slash 命令 / skill 选择器 |
+| `!` 开头 | **Bash 模式** —— 直接跑 shell 命令并把输出加入 context |
+| `@` | 文件路径自动补全 —— 把文件拉进对话 |
+| `#` 开头 | 通过 prompt 写入 CLAUDE.md / auto-memory |
+
+`*` auto 只在你的方案支持时才出现在循环里。
+
+### Slash 命令 —— 研究员精选
+
+输入 `/` 看完整菜单。对咱这种使用场景真值得记住的：
+
+**Session 管理**
+- `/clear`（= `/reset`、`/new`）—— 新对话，旧的仍可 resume
+- `/resume` / `/continue` —— 打开 session 选择器（或传 ID）
+- `/branch [name]` —— 在当前位置分叉对话
+- `/rewind` —— 等同于 `Esc` `Esc`（checkpoint 菜单）
+- `/compact [focus]` —— 总结对话释放 context；可给 focus 提示
+- `/context` —— 可视化当前 context window 被什么占满
+- `/diff` —— 交互式 diff 查看器（git diff + 每轮 diff）
+
+**模式与思考量**
+- `/plan [description]` —— 直接进 plan 模式
+- `/effort low|medium|high|xhigh|max|auto` —— session 级思考预算
+- `/fast` —— 切换 fast Opus 4.6（快 2.5×，贵 —— 交互迭代用）
+- `/model` —— 选模型；支持 effort 的模型可用左右键调
+- `/permissions` —— 交互式增删 allow / ask / deny 规则
+
+**Skills 与 agents**
+- `/skills` —— 列所有 skills（`t` 按 token cost 排序）
+- `/agents` —— 列 / 建 / 改 subagents
+- `/hooks` —— 查看所有已配 hooks
+
+**Bundled skills —— 研究员金矿**
+- `/claude-api` —— 为你的语言（Python / TS / …）加载 Claude API 参考 + Managed Agents 参考。`import anthropic` 会自动触发。写 API 代码时超好用。
+- `/simplify [focus]` —— 对最近改过的文件并行派 3 个 review agent，汇总，应用修复
+- `/debug [description]` —— 开 debug 日志，排障
+- `/review [PR]` —— 本地 PR review
+- `/security-review` —— 扫当前分支 pending 改动的注入 / 鉴权 / 数据泄露风险
+- `/loop [interval] [prompt]` —— 反复跑 prompt；不给 interval 时 Claude 自己调速。监控长实验杀手级。
+- `/fewer-permission-prompts` —— 扫 transcript，把你反复批准的只读 bash 命令加到项目 allowlist
+
+**自省**
+- `/status` —— 版本、模型、账号、每字段来自哪层 settings
+- `/doctor` —— 诊断安装 + 配置（`f` 自动修）
+- `/cost` —— 本 session 累计 token 消耗
+- `/insights` —— 分析过去 30 天 session（摩擦点、常用模型）
+- `/stats` —— 日用量图
+- `/recap` —— 一行本 session 摘要
+
+**对外**
+- `/mcp` —— MCP 服务器连接
+- `/plugin` —— marketplace 浏览
+- `/export [file]` —— 导出对话为纯文本
+- `/copy [N]` —— 复制倒数第 N 条助手回复（带代码块选择器）
+- `/btw <q>` —— 基于当前 context 问个小旁问，**不进对话历史**
+
+### Plan 模式 —— 什么时候伸手
+
+工作流：`Shift+Tab` 切到"plan" → 描述任务 → Claude 研究（读委托给 **Plan** subagent）→ 出方案 → 你选：
+
+1. **批准 + auto** —— 撒手跑（如果有 `auto`）
+2. **批准 + accept edits** —— 跑，跳过编辑 prompt
+3. **批准 + manual** —— 跑，每次编辑都问
+4. **继续规划，带反馈** —— 迭代
+5. **用 Ultraplan 精修** —— 浏览器多 agent review（需订阅）
+
+每个批准选项还可以**先清掉规划 context** —— 研究阶段把 context 撑大但实施小的情况很好用。
+
+大型 refactor 的最佳组合：plan → acceptEdits。审方案（便宜、聚焦）远比审每次编辑（贵、吵）划算。
+
+### Subagents —— 真正常用的那个特性
+
+Subagents = fork 出去的 context window。你只拿到摘要；主对话不会被搜索结果淹。
+
+**内置 subagents，随时可用：**
+
+| Agent | 模型 | 工具 | 什么时候触发 |
+|---|---|---|---|
+| **Explore** | Haiku | 只读 | Claude 需要搜 / 读代码但不动时自动派。thoroughness 级别：`quick` / `medium` / `very thorough`。 |
+| **Plan** | 继承 | 只读 | Plan 模式的研究助手。防止无限嵌套。 |
+| **general-purpose** | 继承 | 全部 | 需要既探索又动手的复杂多步工作。 |
+| **statusline-setup** | Sonnet | — | 跑 `/statusline` 时触发。 |
+| **Claude Code Guide** | Haiku | — | 你问 Claude Code 自己的功能时。 |
+
+**Explore 是读新 codebase / 论文 repo 的单点最实用特性。** 问一句"这个 repo 的训练循环怎么跑的？"—— Claude 派 Explore，回一条摘要，主对话保持干净。
+
+**自定义 subagents** 住在 `~/.claude/agents/<name>.md`。通过 `/agents`（交互式，可"Generate with Claude"）或手写 —— 就是 Markdown + YAML frontmatter：
+
+```markdown
+---
+name: paper-reader
+description: 读 ML 论文的 PDF / repo 并总结 method / novelty / limitations。用户给论文 URL 或问"这论文有什么新东西？"时触发。
+tools: Read, Grep, Glob, WebFetch
+model: sonnet
+---
+
+读论文时：
+1. Method：一段话，公式内嵌
+2. Novelty：跟最近相关工作有什么区别？
+3. Limitations：作者没说、审稿人会问的
+4. Reproducibility：repo 跟论文对得上吗？
+```
+
+存到 `~/.claude/agents/paper-reader.md` → 每个项目都可用。调用：`用 paper-reader agent 总结 …`。
+
+`/agents` → "Running" tab 看活着的 subagents；可以打开 transcript 或停掉某个。
+
+### Agent Teams —— 并行辩论（实验性）
+
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 开启。多个独立的 Claude session 共享一个 task list；teammates 可以**互相发消息**（subagents 不行）。lead 负责汇总。
+
+研究员场景下真能赚回 token 成本：
+
+- **竞争假设 debug**：「5 个 teammate 调查 loss 在第 8k 步发散的不同假设。互相对话试图证伪对方的理论。结果更新到 findings 文档。」
+- **并行评审**：「评审 PR #142 —— security teammate、performance teammate、test-coverage teammate。各自报告。」
+- **多角度设计**：「CLI 设计 —— 一个做 UX，一个做架构，一个扮演 devil's advocate。」
+
+经验值：3–5 个 teammate，每人 5–6 个任务；从研究 / 评审开始（别上来就做实现，容易文件冲突）。token 成本随人数线性增长，所以只在并行探索明显赢过串行时用。
+
+### Skills —— 自带的、自己写的
+
+**Bundled skills** Claude Code 自带；跟自己写的共用 `/` 命名空间。值得背下来：`/claude-api`、`/simplify`、`/debug`、`/loop`、`/review`、`/security-review`、`/init`（生成 CLAUDE.md 起步版）、`/team-onboarding`（根据过去 30 天 session 生成 onboarding 文档）。
+
+**自定义 skills** 放 `~/.claude/skills/<name>/SKILL.md`（user 级）或 `.claude/skills/…`（项目级）。frontmatter 控制谁能调 + 什么工具预批准：
+
+```yaml
+---
+name: benchmark-run
+description: 跑 benchmark 套件，抓 wall-clock + peak memory，格式化成表格
+disable-model-invocation: true   # 只有我能调，不让 Claude 自己触发
+allowed-tools: Bash(python bench/*.py)  Bash(/usr/bin/time *)
+argument-hint: [config-file]
+---
+
+跑 `python bench/run.py $ARGUMENTS`，抓 /usr/bin/time 的 stderr，
+输出 markdown 表格：config、wall_s、peak_rss_mb、tokens/s。
+```
+
+`disable-model-invocation: true` 是**有副作用** skill（deploy、benchmark、send-slack）的杀手字段 —— Claude 不会悄悄触发。`user-invocable: false` 是反向，给"Claude 应该知道但你不会去 `/` 调"的背景知识用。
+
+### Headless 模式 —— 把 Claude Code 当 shell 工具
+
+`claude -p "…"` 非交互式跑。实用场景：
+
+```bash
+# CI 里审 diff
+gh pr diff 123 | claude -p --append-system-prompt "安全审查。标注注入、鉴权、密钥问题。" --output-format json
+
+# 自动 commit 已 staged 的改动
+claude -p "审已 staged 改动并 commit" --allowedTools "Bash(git diff *),Bash(git commit *)"
+
+# 抽结构化数据
+claude -p "列 auth.py 的函数名" \
+  --output-format json \
+  --json-schema '{"type":"object","properties":{"functions":{"type":"array","items":{"type":"string"}}}}' \
+  | jq '.structured_output.functions'
+
+# 每台机结果相同（跳过自动发现）：
+claude --bare -p "总结这篇论文" --allowedTools "Read"
+```
+
+`--bare` 是脚本推荐模式：不读 CLAUDE.md / hooks / plugins / MCP / auto-memory。可复现。跟 `--append-system-prompt-file` 配合，把 prompt 也版本化。
+
+### 研究员 playbook —— 真能赚回投入的场景
+
+**1. 读新论文的 repo。** 在 repo 里开 Claude Code。第一句 prompt：`用 Explore agent (very thorough) 梳理训练管线：数据怎么加载、损失怎么组合、eval 怎么设。返回带 file:line 引用的 markdown 大纲。` 主 context 保持干净，你拿到可导航的大纲。
+
+**2. Debug 一个不稳定的训练跑。** `/plan 第 8k 步 NaN 的根因`。Claude（plan 模式下）读 log 文件、config、model code —— 只读，啥都不动。给出 2-3 个假设。你选一个，按"Approve + accept edits"，它实施修复。
+
+**3. 跨 20 个文件的大 refactor。** Plan 模式 → 审方案 → "Approve + acceptEdits" → 让它跑。中途跑偏就 `Esc` `Esc`（`/rewind`）。`git diff` 是最终审查面。
+
+**4. 长实验看门狗。** `/loop 10m 检查训练是否挂 / loss 是否达标；达标就 commit 并发 slack`。或不给 interval：`/loop` 让 Claude 自己调速。"好了叫我"类工作流神器。
+
+**5. 学 Claude API 本身。** `/claude-api` 加载你语言的 Python 参考 —— tool use、streaming、batch、结构化输出、坑。然后问：`写个最小 agent，用 tool_choice: any 并处理 rate-limit 重试`。
+
+**6. 自己不会 debug 的前端。** 让 auto-memory 积累（"上次发现 Tailwind 类冲突是因为 purge 列表"）。多用 `Esc` `Esc` —— 某次编辑搞坏 UI 就 rewind 到上个能跑的版本，换条路。session 结束后用 `/simplify` 清一清模型留下的乱代码。
+
+**7. 本来要找同事 review 的 PR。** `/review <PR#>` 本地过一遍；`/ultrareview <PR#>` 深度云端多 agent review（Pro / Max 免费 3 次，之后计费）。或开 Agent Team：「3 个 reviewer —— security / performance / tests —— 各自报告。」
+
+**8. 数据管线脚本。** `acceptEdits` 模式 + `claude -p --bare` 适合想完全一致复跑的脚本。项目 settings 里预批准 `Bash(python …)` + `Bash(head|wc|ls …)`，循环里就不会每次 tool 调用都停下问。
+
+### 成本 / 限流 / 退路
+
+- `/cost` 看 session token；`/usage` 看方案配额；`/stats` 是看板。
+- `/fast` 快 2.5× 但 token 也贵 2.5× 且吃 **extra usage**，不吃方案配额。长时间无人值守跑要关。
+- `/effort low` vs `xhigh` —— 越低思考越少 = 越快越便宜 = 硬任务可能出错。我们默认 pin 成 `xhigh`。临时任务可用 `/effort medium` 降档。
+- 撞墙了？`/compact [focus]` 总结对话（保 CLAUDE.md + rules）。`/rewind` 可回滚到没膨胀前。`/clear` 直接重开。
+
+---
+
+## 改设置
+
+1. 编辑 `dot_claude/settings.json`。
+2. `chezmoi diff ~/.claude/settings.json` —— 审渲染后的 diff。
+3. `chezmoi apply ~/.claude/settings.json`。
+4. 若新值是想守护住的，加到 `tests/claude.sh` 的 **Pinned settings fields** 段。
+5. 重启 Claude Code（`Ctrl+D` / exit，再启）—— 大部分 settings 仅启动时读。
+
+## 健康检查
+
+### 自动
+
+```bash
+bash tests/claude.sh
+```
+
+~38 项：binary 存在（`claude`、`bun`、`npx`、`node`），source + target JSON 合法性，每个 pin 的字段，所有 `.chezmoiignore` runtime 排除，插件缓存已填充，`claude --version` + `npx block-no-verify` 解析烟测。
+
+### 手动
+
+- [ ] `claude --version` 正常跑
+- [ ] `claude` 交互式启动，statusLine 渲染（claude-hud bun 输出）
+- [ ] `/hooks` 列出 PreToolUse Bash hook + 所有插件 hooks，没有"command not found"
+- [ ] `/status` 显示 `~/.claude/settings.json` 是 `effortLevel: xhigh` 和 `syntaxHighlightingDisabled: true` 的来源
+- [ ] 在 Claude session 里试 `git commit --no-verify`，被 PreToolUse hook 拦下
+- [ ] `/plugin list` 显示 `claude-hud`、`codex`、`andrej-karpathy-skills` 都启用
+- [ ] 在**另一台** Mac 上 `chezmoi apply` 后：`~/.claude/settings.json` 有同样的 6 个字段
+
+## 排障
+
+| 症状 | 可能原因 | 解决 |
+|---|---|---|
+| `claude: command not found` | Claude Code 没装 | `bootstrap.sh` 跑安装器；单次：`curl -fsSL https://claude.ai/install.sh \| bash` |
+| `statusLine` 空白 | `claude-hud` 插件还没装（`~/.claude/plugins/cache/claude-hud/` 空） | `claude plugin install claude-hud@claude-hud`，重启 |
+| `statusLine` 报 `bun: No such file` | `/opt/homebrew/bin/bun` 没装 | 当前作为 Claude Code 依赖安装；如缺：`brew install oven-sh/bun/bun` |
+| PreToolUse hook：`node: command not found` 或 `npx: command not found` | `node` 缺失（Phase 2 修复回归） | `brew bundle` —— Brewfile 声明了 `node`。根因见 `Brewfile` 注释。 |
+| 插件 `.mjs` hooks 在 session 启动时全挂 | `node` 缺失（同上）—— `openai-codex` 生命周期 hooks shell 出去调 `node` | 同：`brew bundle` |
+| `syntaxHighlightingDisabled: true` 似乎没生效 | 新版本 Claude Code 改了 key 名 | 对照上游[settings 参考](https://code.claude.com/docs/en/settings) —— 该领域在快速演进 |
+| Auto-memory 胀爆 | 某项目 `~/.claude/projects/<proj>/memory/MEMORY.md` > 200 行 → 超出部分不再自动加载 | 跑 `/memory` 精简，或让 Claude offload 到 topic 文件 |
+| `chezmoi apply` 试图创建 `~/.claude/sessions/` / `~/.claude/cache/` | 某个 ignore 规则被删了 | 补回 `.chezmoiignore` —— `tests/claude.sh` 会告诉你哪条 |
+
+## 坑
+
+- **`enabledPlugins` 是声明，不是 vendor**。干掉 `~/.claude/plugins/` 并重启会重新从 marketplace 下载。新 Mac 首次启动需要 GitHub 连通。
+- **`statusLine` 硬编码 `/opt/homebrew/bin/bun`**。Apple Silicon（咱两台）没问题。跨 Intel 或 Linux 会挂 —— 将来真要跨架构，可把 `dot_claude/settings.json.tmpl` 改成 `{{ env "HOMEBREW_PREFIX" }}` 或 `$(command -v bun)`。
+- **别 `chezmoi add ~/.claude`**。它会递归进 runtime 子目录 —— `.chezmoiignore` 挡住多数，但整目录 add 仍可能出意外。按文件 add（`chezmoi add ~/.claude/settings.json`）。
+- **`~/.claude/settings.local.json` 从不 track**，chezmoi 也从不管它，所以本地改动完全带外安全。
+- **Auto-memory 是 machine-local**。工作机上攒的好 MEMORY.md 条目不会跟回家。这是官方设计（[上游文档](https://code.claude.com/docs/en/memory#storage-location)）；要跨机规则，写进 `~/.claude/CLAUDE.md` 并在将来某 phase version 化**那个**。
+- **老 key `includeCoAuthoredBy` 已废弃**。我们 settings 里没有。将来要控制 commit attribution 用新的 `attribution` 对象 —— 2026 settings 文档有。
+
+## 从头重建
+
+若 `~/.claude/settings.json` 被搞坏：
+
+```bash
+chezmoi apply ~/.claude/settings.json
+```
+
+若插件缓存烂了（版本不对、半安装）：
+
+```bash
+rm -rf ~/.claude/plugins
+# 重启 Claude Code —— enabledPlugins + extraKnownMarketplaces 触发重拉。
+```
+
+若 auto-memory 乱了（当前项目的条目过期或错）：
+
+```bash
+rm -rf ~/.claude/projects/<proj>/memory
+# Claude 从头开始重新积累。反正本来就是 per-machine 的，安全。
+```
+
+---
+
+## 相关
+
+- [`Brewfile`](../Brewfile) —— `node` 在那声明；内联注释讲为什么 Claude Code 插件 hooks 需要它
+- [Claude Code settings 参考](https://code.claude.com/docs/en/settings)
+- [Claude Code hooks 参考](https://code.claude.com/docs/en/hooks)
+- [Claude Code memory 参考](https://code.claude.com/docs/en/memory)
+- **Phase 6c**（即将）—— 插件 / MCP / skills 深入 + 内部 vs 外部划分

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "bash -c 'plugin_dir=$(ls -d \"${CLAUDE_CONFIG_DIR:-$HOME/.claude}\"/plugins/cache/claude-hud/claude-hud/*/ 2>/dev/null | awk -F/ '\"'\"'{ print $(NF-1) \"\\t\" $(0) }'\"'\"' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n | tail -1 | cut -f2-); exec \"/opt/homebrew/bin/bun\" --env-file /dev/null \"${plugin_dir}src/index.ts\"'",
+    "padding": 0
+  },
+  "enabledPlugins": {
+    "claude-hud@claude-hud": true,
+    "codex@openai-codex": true,
+    "andrej-karpathy-skills@karpathy-skills": true
+  },
+  "extraKnownMarketplaces": {
+    "claude-hud": {
+      "source": {
+        "source": "github",
+        "repo": "jarrodwatts/claude-hud"
+      }
+    },
+    "openai-codex": {
+      "source": {
+        "source": "github",
+        "repo": "openai/codex-plugin-cc"
+      }
+    },
+    "karpathy-skills": {
+      "source": {
+        "source": "github",
+        "repo": "forrestchang/andrej-karpathy-skills"
+      }
+    }
+  },
+  "syntaxHighlightingDisabled": true,
+  "effortLevel": "xhigh"
+}

--- a/tests/claude.sh
+++ b/tests/claude.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Non-interactive Claude Code config health check. ~1s. Covers binary
+# presence, target-file presence, JSON validity, and a regression guard
+# on every field we intentionally pin in dot_claude/settings.json.
+# Runtime directories under ~/.claude (sessions/, cache/, plugins/, …)
+# are machine-local and ignored on purpose — see .chezmoiignore for the
+# full exclusion list. Manual launch + UI checks are in docs/claude.md →
+# Health check → Manual.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$1"; PASS=$((PASS+1)); }
+bad() { printf "  \033[31m✗\033[0m %s\n" "$1"; [[ -n ${2:-} ]] && printf "    %s\n" "$2"; FAIL=$((FAIL+1)); }
+
+check() {
+    local name=$1 cmd=$2 out
+    if out=$(eval "$cmd" 2>&1); then ok "$name"; else bad "$name" "$out"; fi
+}
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$REPO_ROOT/dot_claude/settings.json"
+TGT="$HOME/.claude/settings.json"
+IGN="$REPO_ROOT/.chezmoiignore"
+
+echo "── Binary ───────────────────────────────────────────"
+check "claude on PATH"                          "command -v claude >/dev/null"
+check "bun on PATH (statusLine)"                "command -v bun >/dev/null"
+check "npx on PATH (PreToolUse hook)"           "command -v npx >/dev/null"
+check "node on PATH (plugin .mjs hooks)"        "command -v node >/dev/null"
+
+echo
+echo "── Source file ──────────────────────────────────────"
+check "dot_claude/settings.json present"        "test -r $SRC"
+check "dot_claude/settings.json is valid JSON"  "python3 -c 'import json,sys; json.load(open(sys.argv[1]))' $SRC"
+
+echo
+echo "── Target file ──────────────────────────────────────"
+check "~/.claude/settings.json present"         "test -r $TGT"
+check "~/.claude/settings.json is valid JSON"   "python3 -c 'import json,sys; json.load(open(sys.argv[1]))' $TGT"
+
+echo
+echo "── Pinned settings fields (source-of-truth grep) ────"
+# Regression guards: these values must survive a source→target render.
+# Grep source only so the check reflects intent, not whatever chezmoi last
+# applied. If chezmoi hasn't been applied yet the target check above will
+# already have failed — this section isolates the source contract.
+check "PreToolUse Bash matcher present"         "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"hooks\"][\"PreToolUse\"][0][\"matcher\"]==\"Bash\"' $SRC"
+check "PreToolUse uses npx block-no-verify"     "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"hooks\"][\"PreToolUse\"][0][\"hooks\"][0][\"command\"]==\"npx block-no-verify@1.1.2\"' $SRC"
+check "statusLine type = command"               "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"statusLine\"][\"type\"]==\"command\"' $SRC"
+check "statusLine shells to bun (Apple Silicon)" "grep -q '/opt/homebrew/bin/bun' $SRC"
+check "claude-hud plugin enabled"               "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"enabledPlugins\"][\"claude-hud@claude-hud\"] is True' $SRC"
+check "openai-codex plugin enabled"             "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"enabledPlugins\"][\"codex@openai-codex\"] is True' $SRC"
+check "karpathy-skills plugin enabled"          "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"enabledPlugins\"][\"andrej-karpathy-skills@karpathy-skills\"] is True' $SRC"
+check "claude-hud marketplace registered"       "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"extraKnownMarketplaces\"][\"claude-hud\"][\"source\"][\"repo\"]==\"jarrodwatts/claude-hud\"' $SRC"
+check "openai-codex marketplace registered"     "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"extraKnownMarketplaces\"][\"openai-codex\"][\"source\"][\"repo\"]==\"openai/codex-plugin-cc\"' $SRC"
+check "karpathy-skills marketplace registered"  "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"extraKnownMarketplaces\"][\"karpathy-skills\"][\"source\"][\"repo\"]==\"forrestchang/andrej-karpathy-skills\"' $SRC"
+check "syntaxHighlightingDisabled = true"       "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"syntaxHighlightingDisabled\"] is True' $SRC"
+check "effortLevel = xhigh"                     "python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d[\"effortLevel\"]==\"xhigh\"' $SRC"
+
+echo
+echo "── Runtime exclusions (.chezmoiignore) ──────────────"
+# Every entry here has a rationale in docs/claude.md → Runtime exclusions.
+# If one disappears from .chezmoiignore, machine-local state can leak
+# into the repo on a future `chezmoi add` — break loud, fix fast.
+for path in \
+    "dot_claude/settings.local.json" \
+    "dot_claude/sessions/**" \
+    "dot_claude/projects/**" \
+    "dot_claude/plans/**" \
+    "dot_claude/plugins/**" \
+    "dot_claude/cache/**" \
+    "dot_claude/file-history/**" \
+    "dot_claude/shell-snapshots/**" \
+    "dot_claude/telemetry/**" \
+    "dot_claude/tasks/**" \
+    "dot_claude/*.jsonl" \
+    "dot_claude/*.log" \
+    "dot_claude/*-cache.json"
+do
+    check "ignored: $path"                       "grep -qF '$path' $IGN"
+done
+
+echo
+echo "── Plugin cache (depends on claude plugin install) ──"
+# statusLine hard-depends on claude-hud being installed. If the cache
+# tree is missing, the spawned bash oneliner silently exec's on nothing
+# and the status line quietly breaks — most users only notice after a
+# few sessions. Catch it here.
+if ls -d "$HOME/.claude/plugins/cache/claude-hud/claude-hud"/*/ >/dev/null 2>&1; then
+    ok "claude-hud plugin cache populated"
+else
+    bad "claude-hud plugin cache populated" "run: claude plugin install claude-hud@claude-hud"
+fi
+check "codex plugin cache populated"             "ls -d $HOME/.claude/plugins/cache/openai-codex/codex/*/ >/dev/null 2>&1"
+check "karpathy-skills plugin cache populated"   "ls -d $HOME/.claude/plugins/cache/karpathy-skills/andrej-karpathy-skills/*/ >/dev/null 2>&1"
+
+echo
+echo "── Smoke ────────────────────────────────────────────"
+check "claude --version runs"                    "claude --version >/dev/null"
+# PreToolUse hook: npx must resolve block-no-verify. Cold network on a
+# fresh Mac will pull it; subsequent runs are cached. --help is the only
+# flag the package supports and proves the binary resolved.
+check "npx block-no-verify resolves"             "npx --no-install block-no-verify@1.1.2 --help >/dev/null 2>&1 || npx -y block-no-verify@1.1.2 --help >/dev/null"
+
+echo
+if [ $FAIL -eq 0 ]; then
+    printf "\n  \033[32m%d passed, 0 failed\033[0m\n" $PASS
+    exit 0
+else
+    printf "\n  \033[31m%d passed, %d failed\033[0m\n" $PASS $FAIL
+    exit 1
+fi

--- a/tests/claude.sh
+++ b/tests/claude.sh
@@ -98,10 +98,14 @@ check "karpathy-skills plugin cache populated"   "ls -d $HOME/.claude/plugins/ca
 echo
 echo "── Smoke ────────────────────────────────────────────"
 check "claude --version runs"                    "claude --version >/dev/null"
-# PreToolUse hook: npx must resolve block-no-verify. Cold network on a
-# fresh Mac will pull it; subsequent runs are cached. --help is the only
-# flag the package supports and proves the binary resolved.
-check "npx block-no-verify resolves"             "npx --no-install block-no-verify@1.1.2 --help >/dev/null 2>&1 || npx -y block-no-verify@1.1.2 --help >/dev/null"
+# PreToolUse hook: block-no-verify must be resolvable by npx. Pure
+# readonly check — `--no-install` fails fast if the package isn't in
+# npx's cache yet, no network, no side effects. On a fresh Mac this
+# check will red until the first Claude Bash call primes the cache via
+# the hook itself (npx auto-installs on first actual invocation). That's
+# a correct signal, not a bug: it says "the hook hasn't been exercised
+# yet on this machine."
+check "npx block-no-verify cached"               "npx --no-install block-no-verify@1.1.2 --help >/dev/null 2>&1"
 
 echo
 if [ $FAIL -eq 0 ]; then


### PR DESCRIPTION
## Summary / 概述

Phase 6b lands the Claude Code config spine: `~/.claude/settings.json` is now source-managed (6 cross-machine fields), every runtime sibling under `~/.claude/` is pre-emptively `.chezmoiignore`-d, and `docs/claude.{md,zh.md}` includes a 2026-fresh usage guide (slash commands, permission modes, subagents, agent teams, skills, headless, researcher playbook).

## Change type / 变更类型

- [x] `feat` — new package / functionality · 新包或新功能
- [ ] `fix`
- [ ] `chore`
- [ ] `docs`
- [ ] `refactor`

## Checklist / 检查清单

- [x] Commit messages follow Conventional Commits
- [x] `pre-commit run --all-files` passes locally
- [x] `chezmoi diff` reviewed — only adds `$schema` to `~/.claude/settings.json`, no deletions, no perm changes
- [ ] New package → entry added to the `Layout` section of `README.md`  <!-- dot_claude/ does not warrant README layout churn on its own; falls under the existing `dot_*` glob -->
- [ ] New CLI tool → added to `Brewfile`  <!-- node was added in PR #15 (fix/node-runtime); this PR consumes that -->
- [x] Smoke-tested end-to-end on this Mac — `tests/claude.sh`: 38 passed, 0 failed

## Notes for reviewer / 给 reviewer 的说明

**Scope boundary with Phase 6c.** This PR covers `settings.json` only. Plugins (`claude-hud` / `codex` / `karpathy-skills`) are *declared* here via `enabledPlugins` / `extraKnownMarketplaces` but their skills / MCP / internal-vs-external split lands in Phase 6c. The docs already scaffold the Phase 6c preview section.

**Three deliberate non-choices** (user ratified during plan phase):

1. **No `{{ if .is_work }}` template** — all 6 fields are currently cross-machine. Work-mac-specific Bash allowlists and feishu-lark / bytedcli entries live in `settings.local.json` (ignored) or MCP-level config.
2. **No user-level `CLAUDE.md` yet** — `~/.claude/CLAUDE.md` is empty today; pre-emptively `.chezmoiignore`-d so nothing sneaks in via `chezmoi add`. Opt in later by deleting that one ignore line.
3. **`plans/` ignored** — `/plan` outputs are machine-local work artifacts, not config.

**Hardcoded `/opt/homebrew/bin/bun` in `statusLine`.** Fine today (both Macs are Apple Silicon). Documented as a gotcha in `docs/claude.md` → **Gotchas**; future `{{ env "HOMEBREW_PREFIX" }}` template noted if we ever cross-arch.

**Usage guide scope.** Deliberately covers what a *solo algorithm researcher* needs — Explore subagent for reading new codebases/papers, plan mode + acceptEdits for refactors, `/loop` for experiment watchers, `/claude-api` for writing against the API, `claude -p --bare` for reproducible scripting. Not exhaustive; not meant to replace upstream docs.

**`tests/claude.sh`** (38 checks): binary presence (`claude`, `bun`, `npx`, `node`), source + target JSON validity, regression guards on every pinned field, every `.chezmoiignore` runtime exclusion, plugin cache populated for all three declared plugins, smoke for `claude --version` + `npx block-no-verify` resolution.

_Generated with Claude Code._