### PR TITLE
feat(nvim): Phase 7a core — kickstart init.lua + lazy.nvim + catppuccin transparent + which-key/mini

### DIFF
--- a/docs/nvim.md
+++ b/docs/nvim.md
@@ -1,0 +1,203 @@
+# Neovim
+
+> English · [中文](nvim.zh.md)
+
+Kickstart-style **single-file** nvim config. The whole config lives in one `init.lua` — read top to bottom, no plugin tree, no distro. This is Phase 7a (core scaffold: options + keymaps + autocmds + 4 base plugins). Phases 7b–7d add navigation / LSP / polish in separate branches.
+
+## How it works
+
+| Thing | Where | Note |
+|---|---|---|
+| Config | `~/.config/nvim/init.lua` ← source `dot_config/nvim/init.lua` | Single file. `vim.g.mapleader = " "` is the first thing to run. |
+| Plugin lock | `~/.config/nvim/lazy-lock.json` ← source `dot_config/nvim/lazy-lock.json` | commit hash per plugin — **tracked**, keeps both Macs on the same versions. |
+| Plugin cache | `~/.local/share/nvim/lazy/<name>` | Populated by `lazy.nvim` on first launch. Not in source. |
+| Undo dir | `~/.local/state/nvim/undo/` | `opt.undofile = true`. Not in source. |
+| Installer | `brew install neovim` (from Brewfile) | No separate install step — `chezmoi apply` → `init.lua` → next `nvim` launch bootstraps lazy. |
+
+## Concepts
+
+**Kickstart-style.** Everything readable in one file. Based on [nvim-lua/kickstart.nvim](https://github.com/nvim-lua/kickstart.nvim). When `init.lua` grows past ~400 lines or LSP config needs its own space, we split into `lua/` sub-modules — not before.
+
+**lazy.nvim.** The plugin manager. Two jobs:
+1. **Bootstrap**: the block near the bottom of `init.lua` clones lazy.nvim into `~/.local/share/nvim/lazy/lazy.nvim` on first launch. Zero submodules, zero brew.
+2. **Spec → install**: `require("lazy").setup({…})` takes a list of plugin specs (`"author/repo"` + `opts` / `event` / `keys`). lazy installs, lazy-loads them on demand, and writes `lazy-lock.json`.
+
+**`lazy-lock.json` is tracked.** It pins each plugin's commit SHA. When the other Mac runs `chezmoi apply` + `nvim`, lazy reads the lock and checks out the exact same commits → identical plugin state across machines. Update by running `:Lazy sync` inside nvim, then `chezmoi add ~/.config/nvim/lazy-lock.json`.
+
+**Karabiner caveat.** This Mac has Karabiner mapping **Caps→Ctrl** and **Ctrl+hjkl→arrow keys** at the OS layer. Consequence: `<C-h>` / `<C-j>` / `<C-k>` / `<C-l>` **never reach nvim** — they come through as `<Left>` / `<Down>` / `<Up>` / `<Right>`. Don't bind those. Safe Ctrl combos: `<C-w>…` (window ops), `<C-d>` / `<C-u>` (half-page), `<C-o>` / `<C-i>` (jump list).
+
+**Color palette.** Catppuccin Mocha — same flavor as starship, ghostty, fastfetch, yazi. The whole terminal reads as one palette.
+
+**Transparency** uses two separate catppuccin switches + an `opt`:
+
+- `transparent_background = true` → unbackgrounds `Normal / NormalNC / SignColumn / EndOfBuffer` (the editor area).
+- `float = { transparent = true }` → unbackgrounds `NormalFloat` and everything linked to it (which-key, telescope, blink.cmp, LSP hover, etc.).
+- `opt.winblend = 0` (+ `opt.pumblend = 0`) → catppuccin only drops float bg when winblend is 0 (`editor.lua:40`: `bg = (float.transparent and winblend == 0) ? none : mantle`).
+
+Drop all three if you move to a non-transparent terminal.
+
+## Keymap reference (Phase 7a)
+
+`<leader>` is `<Space>`. Hold `<leader>` to pop up which-key.
+
+### General
+
+| Keys | Mode | Action |
+|---|---|---|
+| `<Esc>` | normal | Clear search highlight |
+| `<leader>w` | normal | Write buffer |
+| `<leader>e` | normal | Open diagnostic float under cursor |
+| `<leader>?` | normal | Show buffer-local keymaps (which-key) |
+| `[d` / `]d` | normal | Previous / next diagnostic |
+
+### Motion — `H` / `L` override vim defaults
+
+Applied in `{ n, x, o }` (normal + visual + operator-pending) so `dL` / `yH` / `vL` all work.
+
+| Keys | Action | Replaces vim default |
+|---|---|---|
+| `H` | Go to first non-blank char of line (`^`) | Top of viewport — use `zt` / `<C-u>` instead |
+| `L` | Go to end of line (`$`) | Bottom of viewport — use `zb` / `<C-d>` instead |
+
+Normal-mode `K` is intentionally left unbound in 7a; Phase 7c wires it to `vim.lsp.buf.hover()`.
+
+### Visual
+
+| Keys | Action |
+|---|---|
+| `<` / `>` | Indent left / right, keep selection |
+
+### Window / split (vim built-ins, still work because `<C-w>` isn't Karabiner-mapped)
+
+| Keys | Action |
+|---|---|
+| `<C-w>s` / `<C-w>v` | Horizontal / vertical split |
+| `<C-w>h/j/k/l` | Move to window left/down/up/right |
+| `<C-w>c` / `<C-w>o` | Close / keep only this window |
+| `<C-w>=` | Equalize window sizes |
+
+### mini.surround (Phase 7a plugin — LazyVim `gs` prefix)
+
+| Keys | Action |
+|---|---|
+| `gsa{motion}{char}` | Surround add: `gsaiw)` → wrap inner-word with `()` |
+| `gsd{char}` | Surround delete: `gsd"` → remove surrounding `""` |
+| `gsr{old}{new}` | Surround replace: `gsr([` → replace `()` with `[]` |
+| `gsf{char}` / `gsF{char}` | Find next / previous surround |
+| `gsh{char}` | Highlight surround |
+| `gsn` | Update `n_lines` (how far mini.surround looks for a match) |
+
+## Plugins (Phase 7a)
+
+Four plugins. Each line in `init.lua` → one plugin. Future phases append to the same `require("lazy").setup({…})` call.
+
+| Plugin | Role | Load | Notes |
+|---|---|---|---|
+| `catppuccin/nvim` | Colorscheme (Mocha flavor) | eager, `priority = 1000` | Loads before everything else so other plugins pick up catppuccin hl groups. `vim.g.colors_name` reads as `catppuccin-mocha`. |
+| `folke/which-key.nvim` | Keymap discovery popup | `event = "VeryLazy"` | Preset `classic` → full-width borderless bar at the bottom (`width = math.huge`, `col = 0`, `row = -1`). Auto-surfaces `desc` fields from every `vim.keymap.set(..., { desc = "..." })`. Other presets: `helix` = bottom-right 30–60 col box, `modern` = 90% centered rounded float. |
+| `echasnovski/mini.pairs` | Auto-close `() [] {} '' "" \`\`` | `event = "InsertEnter"` | Smart-delete companion bracket if you backspace on one. |
+| `echasnovski/mini.surround` | `gsa/gsd/gsr/gsf/gsF/gsh/gsn` surround ops | `event = "VeryLazy"` | LazyVim-style `gs` prefix. Avoids `s` (reserved for flash in 7b), `ys/ds/cs` vim-surround style (collides with yank/change motions), and `gd/gr/gI` LSP family (7c). |
+
+## Change a setting
+
+1. Edit `dot_config/nvim/init.lua`.
+2. `chezmoi diff ~/.config/nvim/init.lua` — preview.
+3. `chezmoi apply ~/.config/nvim/init.lua` — write.
+4. Reload: inside nvim, `:source %`. Structural changes (plugin specs, autocmds) → restart nvim.
+5. Run `bash tests/nvim.sh` to catch regressions.
+
+## Add a plugin
+
+1. Append a spec inside `require("lazy").setup({…})`:
+
+    ```lua
+    { "author/repo", event = "VeryLazy", opts = { … } },
+    ```
+
+2. Save `init.lua`, relaunch `nvim`. Lazy auto-installs on startup.
+3. `:Lazy sync` inside nvim to also refresh `lazy-lock.json`.
+4. `chezmoi add ~/.config/nvim/init.lua ~/.config/nvim/lazy-lock.json` — vendor both.
+
+Spec keys worth knowing: `event` (lazy-load on `InsertEnter` / `BufReadPre` / `VeryLazy`), `keys` (lazy-load when keymap fires), `cmd` (lazy-load on `:Cmd`), `opts` (sugar — lazy calls `require(plugin).setup(opts)` for you).
+
+## Health check
+
+### Automated
+
+```bash
+bash tests/nvim.sh
+```
+
+21 checks: file presence, nvim/git on PATH, headless `+qa` startup, `Lazy! sync` exit code, all 5 plugin dirs populated (lazy.nvim + 4 Phase 7a), `lazy-lock.json` present, runtime probe (leader, colorscheme, number/relnum/expandtab/tabstop/shiftwidth/undofile/netrw-disabled).
+
+### Manual
+
+Open `nvim some-file.lua` in a real terminal:
+
+- [ ] Splash shows, no red error message
+- [ ] Background is catppuccin mocha purple/plum, not default dark
+- [ ] `:echo mapleader` returns `' '` (a space)
+- [ ] Line numbers visible, relativenumber on (numbers count from cursor)
+- [ ] Type `<Space>` and hold → **which-key popup** appears listing `w / q / Q / e / ?`
+- [ ] `<Space>w` writes the buffer (`:w` runs, no prompt)
+- [ ] In insert mode, type `(` → auto-closes to `()` with cursor between (**mini.pairs**)
+- [ ] Delete the `(` with backspace → the `)` is auto-deleted too
+- [ ] Type a word, normal mode, `gsaiw"` → word gets wrapped in `""` (**mini.surround add**)
+- [ ] On that wrapped word, `gsd"` → quotes removed (**mini.surround delete**)
+- [ ] `gsr"'` on another wrapped word → `""` becomes `''` (**mini.surround replace**)
+- [ ] Press `H` on a line with leading whitespace → cursor jumps to first non-blank char (not col 0)
+- [ ] Press `L` → cursor jumps to end of line
+- [ ] `dL` deletes from cursor to EOL; `yH` yanks from cursor to first non-blank
+- [ ] Yank text (`yy`) → flash highlight lingers briefly (autocmd working)
+- [ ] `:Lazy` opens the plugin manager panel
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `nvim: command not found` | neovim not installed | `brew bundle` — Brewfile declares `neovim`. |
+| Plugins missing / UI looks default | lazy bootstrap didn't run (first launch interrupted) | `nvim --headless '+Lazy! sync' +qa` — or just relaunch nvim. |
+| `E5113: Error while calling lua chunk` on startup | syntax error in `init.lua` | `bash tests/nvim.sh` — the "Headless startup" section prints the error. |
+| Colorscheme is default dark (not catppuccin) | catppuccin plugin failed to load | `:Lazy` → find `catppuccin` → `L` for log. Usually a git clone failure — `:Lazy restore` re-clones. |
+| which-key popup doesn't appear | `timeoutlen` too short or which-key didn't load | `:echo &timeoutlen` should be ≥ 300. `:Lazy show which-key.nvim`. |
+| `<C-h>` / `<C-j>` / `<C-k>` / `<C-l>` mysteriously act as arrow keys | Karabiner is doing that — **by design** | See Concepts → Karabiner caveat. Rebind to `<leader>…` or use `<C-w>…` for windows. |
+| `gsaiw)` doesn't wrap | mini.surround's `gs` prefix got shadowed | `:verbose map gsa` — if another plugin grabbed `gs*`, rebind in mini.surround's `opts.mappings` or unbind the conflict. |
+| `H` / `L` don't jump as expected | another plugin (likely future 7b) re-bound them | `:verbose map H` / `:verbose map L` — find culprit, unmap or change its mapping. |
+| `lazy-lock.json` diff noise after `:Lazy sync` | normal — upstream moved | Commit the update: `chezmoi add ~/.config/nvim/lazy-lock.json`. |
+
+## Gotchas
+
+- **Single file, strict ordering.** `vim.g.mapleader` must be set **before** the lazy block — plugins register keymaps at load time, so they capture whatever `mapleader` is at that moment. Don't reorder.
+- **`<C-h>` family is dead on this Mac.** Karabiner eats them. Every keymap file in this repo assumes that; new bindings should avoid those combos.
+- **Chezmoi manages two files only** in 7a: `init.lua` and `lazy-lock.json`. `~/.local/share/nvim/lazy/` is **destination-only runtime** — don't `chezmoi add` it (would vendor megabytes of plugin source).
+- **Undo is persistent.** `opt.undofile = true` writes to `~/.local/state/nvim/undo/`. Changes you undo after closing/reopening nvim still work — but also means deleted-then-quit files' undo history persists on disk.
+- **`mini.pairs` runs on `InsertEnter`.** First time you enter insert mode after launch has a ~ms stall as it loads. Intentional — keeps cold start fast.
+- **`H` / `L` override vim's viewport jumps.** Vim default: `H` = home-of-viewport, `L` = last-of-viewport. We trade them for line-start / line-end (muscle memory that carries from VS Code / many IDEs). If you need viewport-top, use `zt` / `<C-u>`; viewport-bottom → `zb` / `<C-d>`.
+- **mini.surround uses `gs` not `s`.** `s` in normal mode is kept free for Phase 7b's flash plugin. `gs` in vim default is "gotoSleep" (sleeps for count seconds) — we override it without remorse.
+
+## Rebuild from scratch
+
+```bash
+# Nuke plugin cache + undo history + lazy state. Keeps init.lua and lazy-lock.
+rm -rf ~/.local/share/nvim ~/.local/state/nvim
+
+# Re-apply config + bootstrap:
+chezmoi apply ~/.config/nvim/
+nvim --headless '+Lazy! sync' '+qa'
+```
+
+If `init.lua` itself rots locally:
+
+```bash
+chezmoi apply ~/.config/nvim/init.lua
+```
+
+## Roadmap
+
+What's coming in later phases — tracked in `/Users/bytedance/.claude/plans/0-1-dotfiles-stow-dotfiles-bk-jolly-boole.md`:
+
+- **7b nav**: telescope.nvim / oil.nvim / flash.nvim / gitsigns / lazygit.nvim
+- **7c lsp**: mason + mason-tool-installer / nvim-lspconfig (basedpyright + clangd + lua_ls) / blink.cmp / conform.nvim
+- **7d polish**: nvim-treesitter / lualine / Comment / indent-blankline / todo-comments / undotree
+
+Each is a separate `feat/nvim-*` branch + PR; each adds to this same `init.lua` (and may split into `lua/` sub-modules once the file gets long).

--- a/docs/nvim.zh.md
+++ b/docs/nvim.zh.md
@@ -1,0 +1,203 @@
+# Neovim
+
+> [English](nvim.md) · 中文
+
+Kickstart 风的**单文件** nvim 配置。整份 config 都在一个 `init.lua` 里——从上读到底，没有插件树，不套发行版。本文覆盖 Phase 7a（骨架：options + keymaps + autocmds + 4 个基础插件）。7b–7d 分别加导航 / LSP / 打磨，都走独立 branch。
+
+## 工作原理
+
+| 对象 | 位置 | 说明 |
+|---|---|---|
+| 配置 | `~/.config/nvim/init.lua` ← 源 `dot_config/nvim/init.lua` | 单文件。`vim.g.mapleader = " "` 是最先执行的那行。 |
+| 插件锁 | `~/.config/nvim/lazy-lock.json` ← 源 `dot_config/nvim/lazy-lock.json` | 每插件一个 commit hash — **跟进 repo**，两台 Mac 锁同版本。 |
+| 插件缓存 | `~/.local/share/nvim/lazy/<name>` | `lazy.nvim` 首次启动时写入。**不**在源里。 |
+| 撤销目录 | `~/.local/state/nvim/undo/` | `opt.undofile = true`。不在源里。 |
+| 安装 | `brew install neovim`（Brewfile） | 没有单独安装步骤——`chezmoi apply` → `init.lua` → 下次 `nvim` 启动时自动 bootstrap lazy。 |
+
+## 概念
+
+**Kickstart 风。** 整份配置一文件读完。参考 [nvim-lua/kickstart.nvim](https://github.com/nvim-lua/kickstart.nvim)。等 `init.lua` 超过 ~400 行或 LSP 配置需要自己的空间时，再拆 `lua/` 子模块——不提前拆。
+
+**lazy.nvim。** 插件管理器，干两件事：
+1. **Bootstrap**：`init.lua` 靠下的那段代码首次启动时把 lazy.nvim clone 到 `~/.local/share/nvim/lazy/lazy.nvim`。没有 submodule、不走 brew。
+2. **Spec → install**：`require("lazy").setup({…})` 收一个插件 spec 列表（`"author/repo"` + `opts` / `event` / `keys`）。lazy 按需懒加载，并写 `lazy-lock.json`。
+
+**`lazy-lock.json` 要跟进 repo。** 它锁每个插件的 commit SHA。另一台 Mac `chezmoi apply` + `nvim` 时，lazy 读锁文件、checkout 相同 commit → 两机插件状态完全一致。更新方式：nvim 里 `:Lazy sync`，然后 `chezmoi add ~/.config/nvim/lazy-lock.json`。
+
+**Karabiner 约束。** 本机 Karabiner 在 OS 层把 **Caps→Ctrl**、**Ctrl+hjkl→方向键**。后果：`<C-h>` / `<C-j>` / `<C-k>` / `<C-l>` **到不了 nvim**——它们变成 `<Left>` / `<Down>` / `<Up>` / `<Right>`。不要绑它们。安全 Ctrl 组合：`<C-w>…`（窗口操作）、`<C-d>` / `<C-u>`（半页翻）、`<C-o>` / `<C-i>`（跳转列表）。
+
+**配色。** Catppuccin Mocha——和 starship、ghostty、fastfetch、yazi 同 flavor。整个终端一套配色。
+
+**透明**需要 catppuccin 的两个独立开关 + 一个 `opt`：
+
+- `transparent_background = true` → 不画 `Normal / NormalNC / SignColumn / EndOfBuffer`（编辑区）。
+- `float = { transparent = true }` → 不画 `NormalFloat` 及其 link（which-key、telescope、blink.cmp、LSP hover 等浮窗）。
+- `opt.winblend = 0`（+ `opt.pumblend = 0`）→ catppuccin 只在 winblend=0 时才把浮窗 bg 设为 NONE（`editor.lua:40`：`bg = (float.transparent and winblend == 0) ? none : mantle`）。
+
+换到非透明终端时，三项都去掉。
+
+## 按键参考（Phase 7a）
+
+`<leader>` 是 `<Space>`。按住 `<leader>` 不动 → 弹 which-key。
+
+### 通用
+
+| 键 | 模式 | 动作 |
+|---|---|---|
+| `<Esc>` | normal | 清搜索高亮 |
+| `<leader>w` | normal | 写入 buffer |
+| `<leader>e` | normal | 弹 diagnostic float |
+| `<leader>?` | normal | 列 buffer-local keymap（which-key） |
+| `[d` / `]d` | normal | 上/下个 diagnostic |
+
+### 行内跳转 —— `H` / `L` 覆盖 vim 默认
+
+绑在 `{ n, x, o }`（normal + visual + operator-pending），所以 `dL` / `yH` / `vL` 都能用。
+
+| 键 | 动作 | 被替换的 vim 默认 |
+|---|---|---|
+| `H` | 跳到行首非空白（`^`） | 视口顶部 —— 改用 `zt` / `<C-u>` |
+| `L` | 跳到行尾（`$`） | 视口底部 —— 改用 `zb` / `<C-d>` |
+
+normal 模式的 `K` 7a 故意没绑；7c 会接到 `vim.lsp.buf.hover()`。
+
+### Visual
+
+| 键 | 动作 |
+|---|---|
+| `<` / `>` | 左/右缩进，保持选中 |
+
+### Window / split（vim 内置；`<C-w>` 没被 Karabiner 吃掉）
+
+| 键 | 动作 |
+|---|---|
+| `<C-w>s` / `<C-w>v` | 水平 / 垂直分屏 |
+| `<C-w>h/j/k/l` | 切换到左/下/上/右 window |
+| `<C-w>c` / `<C-w>o` | 关本窗 / 只留本窗 |
+| `<C-w>=` | 等分窗口 |
+
+### mini.surround（Phase 7a 插件，LazyVim `gs` 前缀）
+
+| 键 | 动作 |
+|---|---|
+| `gsa{motion}{char}` | 加 surround：`gsaiw)` → 当前词包 `()` |
+| `gsd{char}` | 删 surround：`gsd"` → 去除外层 `""` |
+| `gsr{old}{new}` | 换 surround：`gsr([` → `()` → `[]` |
+| `gsf{char}` / `gsF{char}` | 下/上一个 surround |
+| `gsh{char}` | 高亮 surround |
+| `gsn` | 更新 `n_lines`（mini.surround 向外搜多少行） |
+
+## 插件（Phase 7a）
+
+四个。`init.lua` 里每一行一个。后续 phase 往同一个 `require("lazy").setup({…})` 追加。
+
+| 插件 | 角色 | 加载 | 备注 |
+|---|---|---|---|
+| `catppuccin/nvim` | 配色（Mocha flavor） | 立即加载，`priority = 1000` | 先加载，其他插件才能拿到 catppuccin 高亮组。`vim.g.colors_name` = `catppuccin-mocha`。 |
+| `folke/which-key.nvim` | keymap 提示弹窗 | `event = "VeryLazy"` | Preset `classic` → 底部全宽无边框条（`width = math.huge`、`col = 0`、`row = -1`）。自动显示 `vim.keymap.set(..., { desc = "..." })` 里的 `desc`。其他 preset：`helix` = 右下 30–60 列小框、`modern` = 居中 90% 圆角浮窗。 |
+| `echasnovski/mini.pairs` | `() [] {} '' "" \`\`` 自动闭合 | `event = "InsertEnter"` | 退格删一个会联动删对侧。 |
+| `echasnovski/mini.surround` | `gsa/gsd/gsr/gsf/gsF/gsh/gsn` surround 操作 | `event = "VeryLazy"` | LazyVim 风 `gs` 前缀。避开 `s`（7b 给 flash）、`ys/ds/cs`（vim-surround 风，撞 yank/change 动作）、`gd/gr/gI`（7c LSP 系列）。 |
+
+## 改配置
+
+1. 编辑 `dot_config/nvim/init.lua`。
+2. `chezmoi diff ~/.config/nvim/init.lua` — 预览。
+3. `chezmoi apply ~/.config/nvim/init.lua` — 写入。
+4. 重载：nvim 里 `:source %`。插件/autocmd 结构改动需要重启。
+5. 跑 `bash tests/nvim.sh` 防回归。
+
+## 加插件
+
+1. 在 `require("lazy").setup({…})` 里追加 spec：
+
+    ```lua
+    { "author/repo", event = "VeryLazy", opts = { … } },
+    ```
+
+2. 保存 `init.lua`，重启 `nvim`，lazy 启动时自动装。
+3. nvim 里 `:Lazy sync` 刷新 `lazy-lock.json`。
+4. `chezmoi add ~/.config/nvim/init.lua ~/.config/nvim/lazy-lock.json` — 两个都 vendor。
+
+常用 spec 键：`event`（`InsertEnter` / `BufReadPre` / `VeryLazy` 等事件懒加载）、`keys`（按键触发懒加载）、`cmd`（`:Cmd` 触发）、`opts`（语法糖，lazy 帮你 `require(plugin).setup(opts)`）。
+
+## Health check
+
+### 自动
+
+```bash
+bash tests/nvim.sh
+```
+
+21 项检查：文件在位、nvim/git 在 PATH、headless `+qa` 启动、`Lazy! sync` 退出码、5 个插件目录（lazy.nvim + 4 个 7a）、`lazy-lock.json` 在位、runtime 探针（leader、colorscheme、number/relnum/expandtab/tabstop/shiftwidth/undofile/netrw-disabled）。
+
+### 手动
+
+真实终端里 `nvim some-file.lua`：
+
+- [ ] splash 显示，无红字报错
+- [ ] 背景是 catppuccin mocha 紫红系，不是默认深色
+- [ ] `:echo mapleader` 返回 `' '`（一个空格）
+- [ ] 行号可见，relativenumber 开启（光标外的行是相对数）
+- [ ] 按 `<Space>` 不放 → **which-key 弹窗**列出 `w / q / Q / e / ?`
+- [ ] `<Space>w` 写入 buffer（`:w` 执行，无 prompt）
+- [ ] insert 模式输入 `(` → 自动补 `()` 光标夹中（**mini.pairs**）
+- [ ] 退格删 `(` → `)` 联动删
+- [ ] normal 模式 `gsaiw"` → 当前词被 `""` 包起（**mini.surround 加**）
+- [ ] 在包好的词上 `gsd"` → 引号删掉（**mini.surround 删**）
+- [ ] `gsr"'` → `""` 变 `''`（**mini.surround 换**）
+- [ ] 行首有缩进时按 `H` → 光标跳到第一个非空白字符（不是 col 0）
+- [ ] 按 `L` → 光标跳到行尾
+- [ ] `dL` 删到行尾；`yH` yank 到行首非空白
+- [ ] `yy` yank 文本 → 一瞬高亮闪烁（autocmd 生效）
+- [ ] `:Lazy` 打开插件管理面板
+
+## Troubleshooting
+
+| 症状 | 原因 | 修 |
+|---|---|---|
+| `nvim: command not found` | neovim 没装 | `brew bundle` — Brewfile 已声明 `neovim`。 |
+| 插件没装 / UI 默认样 | 首次 lazy bootstrap 中断 | `nvim --headless '+Lazy! sync' +qa` — 或直接重启 nvim。 |
+| 启动 `E5113: Error while calling lua chunk` | `init.lua` 语法错 | `bash tests/nvim.sh` — Headless 那段会打错。 |
+| 颜色是默认深色（非 catppuccin） | catppuccin 加载失败 | `:Lazy` → 找 `catppuccin` → `L` 看 log。多半 git clone 失败 → `:Lazy restore`。 |
+| which-key 弹窗不出现 | `timeoutlen` 太短或插件没加载 | `:echo &timeoutlen` 应 ≥ 300。`:Lazy show which-key.nvim`。 |
+| `<C-h>` / `<C-j>` / `<C-k>` / `<C-l>` 神秘地当方向键 | Karabiner 做的——**故意** | 见概念 → Karabiner 约束。改绑 `<leader>…` 或用 `<C-w>…` 管窗口。 |
+| `gsaiw)` 不 surround | mini.surround 的 `gs` 被其他插件抢了 | `:verbose map gsa` — 找到冲突后解绑，或改 mini.surround 的 `opts.mappings`。 |
+| `H` / `L` 跳转不对 | 其他插件（多半 7b 加入时）重绑了 | `:verbose map H` / `:verbose map L` — 找到来源、改掉或解绑。 |
+| `lazy-lock.json` `:Lazy sync` 后 diff 很大 | 正常——上游动了 | commit 更新：`chezmoi add ~/.config/nvim/lazy-lock.json`。 |
+
+## Gotchas
+
+- **单文件，顺序严格。** `vim.g.mapleader` 必须在 lazy 块**之前**——插件在加载时注册 keymap，用的是那一刻的 `mapleader` 值。不要调序。
+- **`<C-h>` 家族在本机废了。** Karabiner 吃掉了。仓库里所有 keymap 都按此约束写；新绑键避开。
+- **Chezmoi 只管两个文件**（7a）：`init.lua` 和 `lazy-lock.json`。`~/.local/share/nvim/lazy/` 是**目标端运行时**——不要 `chezmoi add`（会把几十 MB 插件源码拖进 repo）。
+- **undo 持久化。** `opt.undofile = true` 写到 `~/.local/state/nvim/undo/`。nvim 关了再开还能撤销——但也意味着删过的文件的 undo 历史留在盘上。
+- **`mini.pairs` 在 `InsertEnter` 加载。** 启动后第一次进 insert 模式有 ~ms 延迟加载。故意的——保冷启动快。
+- **`H` / `L` 覆盖 vim 视口跳转。** vim 默认 `H` = 视口顶、`L` = 视口底。这里换成行首/行尾（VS Code / 多数 IDE 的肌肉记忆）。需要视口顶 → `zt` / `<C-u>`；视口底 → `zb` / `<C-d>`。
+- **mini.surround 用 `gs` 而非 `s`。** `s` 留给 7b 的 flash。vim 默认 `gs` 是 "gotoSleep"（按计数秒睡眠），覆盖无损。
+
+## 从零重建
+
+```bash
+# 清插件缓存 + undo 历史 + lazy state。保留 init.lua 和 lazy-lock。
+rm -rf ~/.local/share/nvim ~/.local/state/nvim
+
+# 重新 apply + bootstrap：
+chezmoi apply ~/.config/nvim/
+nvim --headless '+Lazy! sync' '+qa'
+```
+
+若 `init.lua` 本机烂了：
+
+```bash
+chezmoi apply ~/.config/nvim/init.lua
+```
+
+## Roadmap
+
+后续 phase——计划文档：`/Users/bytedance/.claude/plans/0-1-dotfiles-stow-dotfiles-bk-jolly-boole.md`：
+
+- **7b nav**：telescope.nvim / oil.nvim / flash.nvim / gitsigns / lazygit.nvim
+- **7c lsp**：mason + mason-tool-installer / nvim-lspconfig（basedpyright + clangd + lua_ls）/ blink.cmp / conform.nvim
+- **7d polish**：nvim-treesitter / lualine / Comment / indent-blankline / todo-comments / undotree
+
+每个一个 `feat/nvim-*` branch + PR；都往同一个 `init.lua` 追加（超过 ~400 行或 LSP 需要独立文件时再拆 `lua/`）。

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -22,7 +22,9 @@ opt.expandtab = true
 opt.tabstop = 4
 opt.softtabstop = 4
 opt.shiftwidth = 4
-opt.smartindent = true
+-- No smartindent: it predates filetype plugins and does weird things (notably
+-- Python `#` comments getting re-indented to col 0 because C preprocessor
+-- semantics). nvim ships per-filetype indent under runtime/indent/ — better.
 
 opt.wrap = false
 opt.linebreak = true
@@ -41,7 +43,9 @@ opt.splitbelow = true
 opt.swapfile = false
 opt.backup = false
 opt.undofile = true
-opt.undodir = vim.fn.stdpath("state") .. "/undo"
+-- undodir defaults to stdpath("state").."/undo//" — the trailing `//` tells
+-- nvim to encode the full path into the undo filename, preventing collisions
+-- between same-basename files in different dirs. Don't override, default wins.
 
 opt.updatetime = 250
 opt.timeoutlen = 400
@@ -166,7 +170,10 @@ require("lazy").setup({
     },
 
     -- Auto-close + smart-delete for () [] {} '' "" ``.
-    { "echasnovski/mini.pairs",    version = false, event = "InsertEnter", opts = {} },
+    -- version = "*" tracks the latest semver tag (mini.nvim ships v0.15/0.16/…).
+    -- lazy-lock.json is still the authoritative pin — `version` only affects
+    -- which commit `:Lazy update` selects.
+    { "echasnovski/mini.pairs",    version = "*",   event = "InsertEnter", opts = {} },
 
     -- LazyVim-style `gs` prefix (add=gsa delete=gsd replace=gsr find=gsf
     -- find_left=gsF highlight=gsh update_n_lines=gsn). Avoids `s` (reserved
@@ -174,7 +181,7 @@ require("lazy").setup({
     -- `gd/gr/gI` (LSP go-to family in 7c).
     {
         "echasnovski/mini.surround",
-        version = false,
+        version = "*",
         event = "VeryLazy",
         opts = {
             mappings = {

--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -1,0 +1,194 @@
+-- kickstart-style single-file nvim config.
+-- See docs/nvim.md for orientation, keymap reference, and health checks.
+--
+-- Phase 7a (core):  options + keymaps + autocmds + lazy bootstrap
+--                   + catppuccin / which-key / mini.pairs / mini.surround
+-- Phase 7b (nav):   telescope / oil / flash / gitsigns / lazygit  [TODO]
+-- Phase 7c (lsp):   mason / lspconfig / blink.cmp / conform        [TODO]
+-- Phase 7d (polish):treesitter / lualine / comment / indent-blankline / todo [TODO]
+
+-- ─── Leader (must come before any plugin loads) ─────────────────────────────
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+
+-- ─── Options ────────────────────────────────────────────────────────────────
+local opt = vim.opt
+
+opt.number = true
+opt.relativenumber = true
+opt.cursorline = true
+
+opt.expandtab = true
+opt.tabstop = 4
+opt.softtabstop = 4
+opt.shiftwidth = 4
+opt.smartindent = true
+
+opt.wrap = false
+opt.linebreak = true
+opt.scrolloff = 10
+opt.sidescrolloff = 8
+opt.signcolumn = "yes"
+
+opt.ignorecase = true
+opt.smartcase = true
+opt.hlsearch = false
+opt.incsearch = true
+
+opt.splitright = true
+opt.splitbelow = true
+
+opt.swapfile = false
+opt.backup = false
+opt.undofile = true
+opt.undodir = vim.fn.stdpath("state") .. "/undo"
+
+opt.updatetime = 250
+opt.timeoutlen = 400
+
+opt.termguicolors = true
+opt.background = "dark"
+
+opt.clipboard = "unnamedplus"
+opt.mouse = "a"
+
+-- Required companion to catppuccin's float.transparent — NormalFloat only
+-- goes bg=NONE when winblend is 0. See catppuccin editor.lua:40.
+opt.winblend = 0
+opt.pumblend = 0
+
+opt.completeopt = { "menu", "menuone", "noselect" }
+
+opt.list = true
+opt.listchars = { tab = "» ", trail = "·", nbsp = "␣" }
+
+-- Karabiner on this machine maps Caps→Ctrl and Ctrl+hjkl→arrow keys at the OS
+-- layer. That means <C-h/j/k/l> never reach nvim — avoid binding them. Use
+-- <leader>…, <C-w>… (window ops), and arrow keys instead.
+vim.g.loaded_netrw = 1      -- oil.nvim will replace netrw in Phase 7b
+vim.g.loaded_netrwPlugin = 1
+
+-- ─── Keymaps ────────────────────────────────────────────────────────────────
+local map = vim.keymap.set
+
+map("n", "<Esc>", "<cmd>nohlsearch<CR>", { desc = "Clear search highlight" })
+
+-- File ops (leader-prefixed; which-key will document these)
+map("n", "<leader>w", "<cmd>write<CR>", { desc = "Write buffer" })
+
+-- H / L jump to first non-blank / end of line in every mode that motions
+-- can operate in (n = normal, x = visual, o = operator-pending). So `dL`
+-- deletes to EOL, `yH` yanks to BOL, `vL` selects to EOL, etc.
+map({ "n", "x", "o" }, "H", "^", { desc = "Go to first non-blank char" })
+map({ "n", "x", "o" }, "L", "$", { desc = "Go to end of line" })
+
+-- Visual-mode indent keeps selection
+map("v", "<", "<gv", { desc = "Indent left + reselect" })
+map("v", ">", ">gv", { desc = "Indent right + reselect" })
+
+-- Diagnostics (LSP comes in 7c; these still work with vim.diagnostic today).
+-- Normal-mode K is intentionally left unbound here — Phase 7c wires it to
+-- vim.lsp.buf.hover() on LSP-attach.
+map("n", "[d", vim.diagnostic.goto_prev, { desc = "Previous diagnostic" })
+map("n", "]d", vim.diagnostic.goto_next, { desc = "Next diagnostic" })
+map("n", "<leader>e", vim.diagnostic.open_float, { desc = "Diagnostic float" })
+
+-- ─── Autocmds ───────────────────────────────────────────────────────────────
+vim.api.nvim_create_autocmd("TextYankPost", {
+    desc = "Highlight yanked text",
+    group = vim.api.nvim_create_augroup("kickstart-highlight-yank", { clear = true }),
+    callback = function() vim.highlight.on_yank() end,
+})
+
+-- ─── Bootstrap lazy.nvim ────────────────────────────────────────────────────
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+    local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+    local out = vim.fn.system({
+        "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath,
+    })
+    if vim.v.shell_error ~= 0 then
+        vim.api.nvim_echo({
+            { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+            { out, "WarningMsg" },
+            { "\nPress any key to exit..." },
+        }, true, {})
+        vim.fn.getchar()
+        os.exit(1)
+    end
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- ─── Plugins ────────────────────────────────────────────────────────────────
+require("lazy").setup({
+    -- Colorscheme. Loaded eagerly + priority=1000 so other plugins pick up
+    -- catppuccin highlight groups on first render.
+    {
+        "catppuccin/nvim",
+        name = "catppuccin",
+        priority = 1000,
+        lazy = false,
+        opts = {
+            flavour = "mocha",
+            -- Inherit ghostty's background (terminal is transparent, so is nvim).
+            -- transparent_background handles Normal/NormalNC/SignColumn/EndOfBuffer;
+            -- float.transparent handles NormalFloat + every plugin float (which-key,
+            -- telescope, blink.cmp, lsp hover). Both needed together with winblend=0
+            -- (see editor.lua:40: bg=(float.transparent and winblend==0) ? none : mantle).
+            transparent_background = true,
+            float = { transparent = true, solid = false },
+            integrations = {
+                mini = { enabled = true },
+                which_key = true,
+                -- 7b+ will enable telescope / gitsigns / blink_cmp here.
+            },
+        },
+        config = function(_, o)
+            require("catppuccin").setup(o)
+            vim.cmd.colorscheme("catppuccin")
+        end,
+    },
+
+    -- Hold any prefix (e.g. <leader>) → popup lists available bindings.
+    -- classic preset = full-width bar at bottom, borderless. (helix = tiny
+    -- bottom-right box; modern = 90% centered float.)
+    {
+        "folke/which-key.nvim",
+        event = "VeryLazy",
+        opts = { preset = "classic" },
+        keys = {
+            {
+                "<leader>?",
+                function() require("which-key").show({ global = false }) end,
+                desc = "Buffer-local keymaps",
+            },
+        },
+    },
+
+    -- Auto-close + smart-delete for () [] {} '' "" ``.
+    { "echasnovski/mini.pairs",    version = false, event = "InsertEnter", opts = {} },
+
+    -- LazyVim-style `gs` prefix (add=gsa delete=gsd replace=gsr find=gsf
+    -- find_left=gsF highlight=gsh update_n_lines=gsn). Avoids `s` (reserved
+    -- for flash in 7b), `ys/ds/cs` (collide with yank/change motions), and
+    -- `gd/gr/gI` (LSP go-to family in 7c).
+    {
+        "echasnovski/mini.surround",
+        version = false,
+        event = "VeryLazy",
+        opts = {
+            mappings = {
+                add            = "gsa",
+                delete         = "gsd",
+                find           = "gsf",
+                find_left      = "gsF",
+                highlight      = "gsh",
+                replace        = "gsr",
+                update_n_lines = "gsn",
+            },
+        },
+    },
+}, {
+    ui = { border = "rounded" },
+    change_detection = { notify = false },
+})

--- a/dot_config/nvim/lazy-lock.json
+++ b/dot_config/nvim/lazy-lock.json
@@ -1,0 +1,7 @@
+{
+  "catppuccin": { "branch": "main", "commit": "426dbebe06b5c69fd846ceb17b42e12f890aedf1" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "mini.pairs": { "branch": "main", "commit": "42387c7fe68fc0b6e95eaf37f1bb76e7bffaa0d9" },
+  "mini.surround": { "branch": "main", "commit": "2715e04bea3ec9244f15b421dc5b18c0fe326210" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
+}

--- a/tests/nvim.sh
+++ b/tests/nvim.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Non-interactive nvim health check. Covers Phase 7a (core) — options parse,
+# lazy.nvim bootstraps, the 4 Phase 7a plugins install, catppuccin loads.
+# Visual checks (colors, which-key popup, mini.pairs/surround interaction)
+# live in docs/nvim.md → Health check → Manual.
+set -uo pipefail
+
+PASS=0
+FAIL=0
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$1"; PASS=$((PASS+1)); }
+bad() { printf "  \033[31m✗\033[0m %s\n" "$1"; [[ -n ${2:-} ]] && printf "    %s\n" "$2"; FAIL=$((FAIL+1)); }
+
+check() {
+    local name=$1 cmd=$2 out
+    if out=$(eval "$cmd" 2>&1); then ok "$name"; else bad "$name" "$out"; fi
+}
+
+NVIM_CONFIG="$HOME/.config/nvim"
+NVIM_DATA="$HOME/.local/share/nvim"
+
+echo "── File presence ────────────────────────────────────"
+check "~/.config/nvim/init.lua"        "test -r $NVIM_CONFIG/init.lua"
+
+echo
+echo "── Lua syntax (luac -p if available) ────────────────"
+if command -v luac >/dev/null 2>&1; then
+    check "init.lua parses (luac -p)"  "luac -p $NVIM_CONFIG/init.lua"
+else
+    ok "luac not installed — skipping (headless nvim below catches errors)"
+fi
+
+echo
+echo "── Binary on PATH ───────────────────────────────────"
+check "nvim"                           "command -v nvim >/dev/null"
+check "git (needed for lazy clone)"    "command -v git >/dev/null"
+
+echo
+echo "── Headless startup ─────────────────────────────────"
+# A clean +qa run is the strongest smoke test: parses init.lua, bootstraps
+# lazy.nvim, evaluates plugin specs. stderr is captured separately because
+# lazy prints install progress to stdout.
+startup_err=$(nvim --headless '+qa' 2>&1 >/dev/null)
+if [[ -z "$startup_err" ]]; then
+    ok "nvim --headless +qa exits clean"
+else
+    # Lazy's first-run install prints to stderr under some builds; only fail
+    # if the message mentions "Error" or "E".
+    if grep -qE 'E[0-9]+:|Error' <<<"$startup_err"; then
+        bad "nvim --headless +qa exits clean" "$startup_err"
+    else
+        ok "nvim --headless +qa exits clean (startup warnings are benign)"
+    fi
+fi
+
+echo
+echo "── Lazy sync (installs missing plugins on first run) ─"
+# --headless "+Lazy! sync" installs without the TUI. `Lazy!` blocks until done.
+sync_log=$(mktemp)
+if nvim --headless '+Lazy! sync' '+qa' >"$sync_log" 2>&1; then
+    ok "lazy sync completes"
+else
+    bad "lazy sync completes" "$(tail -n 20 "$sync_log")"
+fi
+
+echo
+echo "── Plugin directories populated ─────────────────────"
+for p in lazy.nvim catppuccin which-key.nvim mini.pairs mini.surround; do
+    check "$p installed"               "test -d $NVIM_DATA/lazy/$p"
+done
+
+echo
+echo "── Lock file ────────────────────────────────────────"
+check "lazy-lock.json exists"          "test -r $NVIM_CONFIG/lazy-lock.json"
+
+echo
+echo "── Runtime probe (colorscheme / leader / opts) ──────"
+probe=$(nvim --headless \
+    -c 'lua print("K_LEADER=" .. vim.g.mapleader)' \
+    -c 'lua print("K_COLORS=" .. (vim.g.colors_name or ""))' \
+    -c 'lua print("K_NUMBER=" .. tostring(vim.opt.number:get()))' \
+    -c 'lua print("K_RELNUM=" .. tostring(vim.opt.relativenumber:get()))' \
+    -c 'lua print("K_EXPANDTAB=" .. tostring(vim.opt.expandtab:get()))' \
+    -c 'lua print("K_TS=" .. tostring(vim.opt.tabstop:get()))' \
+    -c 'lua print("K_SW=" .. tostring(vim.opt.shiftwidth:get()))' \
+    -c 'lua print("K_UNDOFILE=" .. tostring(vim.opt.undofile:get()))' \
+    -c 'lua print("K_NETRW=" .. tostring(vim.g.loaded_netrw))' \
+    '+qa' 2>&1)
+
+get() { awk -F= -v k="$1" '$1==k { sub(/^[^=]+=/, ""); print; exit }' <<<"$probe"; }
+export -f get
+export probe
+
+check "mapleader = <space>"            '[[ "$(get K_LEADER)" == " " ]]'
+check "colorscheme = catppuccin*"      '[[ "$(get K_COLORS)" == catppuccin* ]]'
+check "number on"                      '[[ "$(get K_NUMBER)" == true ]]'
+check "relativenumber on"              '[[ "$(get K_RELNUM)" == true ]]'
+check "expandtab on (spaces, not tabs)" '[[ "$(get K_EXPANDTAB)" == true ]]'
+check "tabstop = 4"                    '[[ "$(get K_TS)" == 4 ]]'
+check "shiftwidth = 4"                 '[[ "$(get K_SW)" == 4 ]]'
+check "undofile on"                    '[[ "$(get K_UNDOFILE)" == true ]]'
+check "netrw disabled (1)"             '[[ "$(get K_NETRW)" == 1 ]]'
+
+echo
+echo "─────────────────────────────────────────────────────"
+if (( FAIL > 0 )); then
+    printf "  \033[31m%d passed, %d failed\033[0m\n" $PASS $FAIL
+    echo
+    echo "  Visual features (catppuccin colors in a real TTY, which-key popup,"
+    echo "  mini.pairs auto-close, mini.surround sa/sd/sr) are NOT covered —"
+    echo "  open nvim and run the Manual checklist in docs/nvim.md."
+    exit 1
+fi
+printf "  \033[32m%d passed, %d failed\033[0m\n" $PASS $FAIL
+echo
+echo "  Automated checks OK. Visual features still need a real TTY —"
+echo "  see docs/nvim.md → Health check → Manual."


### PR DESCRIPTION
## Summary / 概述

Phase 7a of the umbrella nvim rebuild. Single-file kickstart-style `init.lua` — options + keymaps + autocmds + lazy bootstrap + 4 base plugins (catppuccin / which-key / mini.pairs / mini.surround). Nothing else touched.

首个 nvim 子阶段：kickstart 单文件风 `init.lua` + lazy + 4 个基础插件，后续 7b/7c/7d 分别跟进导航 / LSP / 打磨。

## Change type / 变更类型

- [x] `feat` — new package

## Checklist / 检查清单

- [x] Commit messages follow Conventional Commits
- [x] `pre-commit run --all-files` passes locally
- [x] `chezmoi diff` reviewed; no surprising deletions or permission changes
- [x] New package → tracked in `dot_config/nvim/` (README Layout section already covers `dot_*` generically; no new top-level section needed)
- [ ] New CLI tool → `neovim` already in Brewfile (Phase 2)
- [x] Smoke-tested end-to-end on this Mac (see Health check in `docs/nvim.md`)

## Key decisions / 关键决策

- **Single file over lua/ tree.** Kickstart philosophy — read top to bottom. We'll split once the file gets past ~400 lines or LSP (7c) needs its own space.
- **Karabiner-aware bindings.** Caps→Ctrl and Ctrl+hjkl→arrows at the OS layer mean `<C-h/j/k/l>` never reach nvim. All bindings avoid them.
- **Transparency = 3 switches, not 1.** `transparent_background` covers Normal; `float.transparent` covers NormalFloat (which-key / telescope / LSP hover); `winblend = 0` is catppuccin's guard (`editor.lua:40`: `bg = (float.transparent AND winblend == 0) ? none : mantle`). All three needed — matches LazyVim's colorscheme extra.
- **mini.surround prefix = `gs` (LazyVim style).** Avoids `s` (reserved for flash in 7b), `ys/ds/cs` (vim-surround collides with yank/change motions), `gd/gr/gI` (LSP go-to family in 7c).
- **`H` / `L` → `^` / `$`** in `{n, x, o}` modes. Trades vim's viewport jumps for line-start/end; `zt`/`zb` + `<C-u>`/`<C-d>` cover the lost motions.
- **Normal `K` intentionally unbound.** Phase 7c wires it to `vim.lsp.buf.hover()`.

## Tests

```
$ bash tests/nvim.sh
... 21 passed, 0 failed
```

21 checks: file presence, nvim/git on PATH, headless `+qa`, `Lazy! sync` exit code, 5 plugin dirs populated, `lazy-lock.json` present, runtime probe for leader / colorscheme / number / relnum / expandtab / tabstop / shiftwidth / undofile / netrw-disabled.

Visual checks (catppuccin colors in TTY, which-key popup, mini.pairs auto-close, mini.surround `gsa/gsd/gsr`, `H`/`L` motion, transparency through ghostty) live in `docs/nvim.md` → Health check → Manual. Smoke-tested by hand during bring-up.

## Notes for reviewer / 给 reviewer 的说明

- Plugin cache (`~/.local/share/nvim/lazy/**`) is **not** vendored — destination-only. `lazy-lock.json` IS vendored so the other Mac pins the same commits.
- The `<leader>` munging order matters: `vim.g.mapleader = " "` must run before `require("lazy").setup(...)`, since plugins register keymaps at load time using the leader-value at that moment. Don't reorder when touching the file later.
- 7b/7c/7d roadmap is in the TODO comment at the top of `init.lua` and at the bottom of `docs/nvim.md`.
- Related plan file (local only, not committed): `/Users/bytedance/.claude/plans/0-1-dotfiles-stow-dotfiles-bk-jolly-boole.md`.

_Generated with Claude Code._